### PR TITLE
[feat] : JWT 인증 인가 세팅

### DIFF
--- a/api/src/main/java/dev/handsup/auction/controller/AuctionController.java
+++ b/api/src/main/java/dev/handsup/auction/controller/AuctionController.java
@@ -11,6 +11,7 @@ import dev.handsup.auction.dto.AuctionResponse;
 import dev.handsup.auction.dto.RegisterAuctionApiRequest;
 import dev.handsup.auction.dto.RegisterAuctionRequest;
 import dev.handsup.auction.service.AuctionService;
+import dev.handsup.auth.annotation.NoAuth;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -24,6 +25,7 @@ public class AuctionController {
 
 	private final AuctionService auctionService;
 
+	@NoAuth
 	@Operation(summary = "경매 등록 API", description = "경매를 등록한다")
 	@PostMapping
 	public ResponseEntity<AuctionResponse> registerAuction(@Valid @RequestBody RegisterAuctionApiRequest request) {

--- a/api/src/main/java/dev/handsup/auth/annotation/NoAuth.java
+++ b/api/src/main/java/dev/handsup/auth/annotation/NoAuth.java
@@ -1,0 +1,11 @@
+package dev.handsup.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+public @interface NoAuth {
+}

--- a/api/src/main/java/dev/handsup/auth/controller/AuthApiController.java
+++ b/api/src/main/java/dev/handsup/auth/controller/AuthApiController.java
@@ -1,0 +1,66 @@
+package dev.handsup.auth.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.auth.dto.AuthApiMapper;
+import dev.handsup.auth.dto.AuthApiRequest;
+import dev.handsup.auth.dto.TokenReIssueApiRequest;
+import dev.handsup.auth.dto.request.AuthRequest;
+import dev.handsup.auth.dto.response.AuthResponse;
+import dev.handsup.auth.jwt.JwtAuthorization;
+import dev.handsup.auth.service.AuthService;
+import dev.handsup.user.domain.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Auth API")
+@RequestMapping("/api/auth")
+@RestController
+@RequiredArgsConstructor
+public class AuthApiController {
+
+	private final AuthService authService;
+
+	@NoAuth
+	@PostMapping("/login")
+	@Operation(summary = "로그인 API", description = "로그인을 한다")
+	@ApiResponse(useReturnTypeSchema = true)
+	public ResponseEntity<AuthResponse> login(
+		@Valid @RequestBody AuthApiRequest request
+	) {
+		AuthRequest authRequest = AuthApiMapper.toAuthRequest(request);
+		AuthResponse authResponse = authService.login(authRequest);
+		return ResponseEntity.ok(authResponse);
+	}
+
+	@PostMapping("/logout")
+	@Operation(summary = "로그아웃 API", description = "로그아웃을 한다")
+	@ApiResponse(useReturnTypeSchema = true)
+	public ResponseEntity<HttpStatus> logout(
+		@Parameter(hidden = true) @JwtAuthorization User user
+	) {
+		authService.logout(user);
+		return ResponseEntity.ok(HttpStatus.OK);
+	}
+
+	@NoAuth
+	@PostMapping("/token")
+	@Operation(summary = "토큰 재발급 API", description = "토큰을 재발급한다")
+	@ApiResponse(useReturnTypeSchema = true)
+	public ResponseEntity<String> reIssueAccessToken(
+		@RequestBody TokenReIssueApiRequest tokenReIssueApiRequest
+	) {
+		String accessToken = authService.createAccessTokenByRefreshToken(tokenReIssueApiRequest.refreshToken());
+		return ResponseEntity.ok(accessToken);
+	}
+}

--- a/api/src/main/java/dev/handsup/auth/dto/AuthApiMapper.java
+++ b/api/src/main/java/dev/handsup/auth/dto/AuthApiMapper.java
@@ -1,0 +1,14 @@
+package dev.handsup.auth.dto;
+
+import static lombok.AccessLevel.*;
+
+import dev.handsup.auth.dto.request.AuthRequest;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public class AuthApiMapper {
+
+	public static AuthRequest toAuthRequest(AuthApiRequest request) {
+		return AuthRequest.of(request.email(), request.password());
+	}
+}

--- a/api/src/main/java/dev/handsup/auth/dto/AuthApiRequest.java
+++ b/api/src/main/java/dev/handsup/auth/dto/AuthApiRequest.java
@@ -1,0 +1,24 @@
+package dev.handsup.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record AuthApiRequest(
+	@Email
+	@NotBlank(message = "email 값이 공백입니다.")
+	String email,
+
+	@NotBlank(message = "password 값이 공백입니다.")
+	String password
+) {
+	public static AuthApiRequest of(String email, String password) {
+		return AuthApiRequest.builder()
+			.email(email)
+			.password(password)
+			.build();
+	}
+
+}

--- a/api/src/main/java/dev/handsup/auth/dto/AuthApiRequest.java
+++ b/api/src/main/java/dev/handsup/auth/dto/AuthApiRequest.java
@@ -1,11 +1,13 @@
 package dev.handsup.auth.dto;
 
+import static lombok.AccessLevel.*;
+
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = PRIVATE)
 public record AuthApiRequest(
 	@Email
 	@NotBlank(message = "email 값이 공백입니다.")

--- a/api/src/main/java/dev/handsup/auth/dto/TokenReIssueApiRequest.java
+++ b/api/src/main/java/dev/handsup/auth/dto/TokenReIssueApiRequest.java
@@ -1,0 +1,9 @@
+package dev.handsup.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenReIssueApiRequest(
+	@NotBlank(message = "refreshToken 값이 공백입니다.")
+	String refreshToken
+) {
+}

--- a/api/src/main/java/dev/handsup/auth/jwt/JwtAuthorization.java
+++ b/api/src/main/java/dev/handsup/auth/jwt/JwtAuthorization.java
@@ -1,0 +1,13 @@
+package dev.handsup.auth.jwt;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ ElementType.PARAMETER, ElementType.ANNOTATION_TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface JwtAuthorization {
+}

--- a/api/src/main/java/dev/handsup/auth/jwt/JwtAuthorizationArgumentResolver.java
+++ b/api/src/main/java/dev/handsup/auth/jwt/JwtAuthorizationArgumentResolver.java
@@ -1,0 +1,50 @@
+package dev.handsup.auth.jwt;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import dev.handsup.auth.service.JwtProvider;
+import dev.handsup.common.exception.NotFoundException;
+import dev.handsup.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationArgumentResolver implements HandlerMethodArgumentResolver {
+
+	private final JwtProvider jwtProvider;
+	private final UserService userService;
+
+	@Override
+	public boolean supportsParameter(MethodParameter parameter) {
+		return parameter.hasParameterAnnotation(JwtAuthorization.class);
+	}
+
+	@Override
+	public Object resolveArgument(
+		@NonNull MethodParameter parameter,
+		ModelAndViewContainer mavContainer,
+		NativeWebRequest webRequest,
+		WebDataBinderFactory binderFactory
+	) {
+		HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+
+		if (httpServletRequest != null) {
+			String accessToken = httpServletRequest.getHeader(HttpHeaders.AUTHORIZATION);
+			Long userId = jwtProvider.getClaim(accessToken);
+			return userService.getUserById(userId);
+		}
+
+		throw new NotFoundException(NOT_FOUND_REQUEST);
+	}
+
+}

--- a/api/src/main/java/dev/handsup/auth/jwt/JwtInterceptor.java
+++ b/api/src/main/java/dev/handsup/auth/jwt/JwtInterceptor.java
@@ -1,0 +1,47 @@
+package dev.handsup.auth.jwt;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.auth.exception.AuthException;
+import dev.handsup.auth.service.JwtProvider;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtInterceptor implements HandlerInterceptor {
+
+	private final JwtProvider jwtProvider;
+
+	private boolean isAnnotationPresent(Object handler) {
+		HandlerMethod handlerMethod = (HandlerMethod)handler;
+		return handlerMethod.getMethodAnnotation(NoAuth.class) != null;
+	}
+
+	@Override
+	public boolean preHandle(
+		@NonNull HttpServletRequest request,
+		@NonNull HttpServletResponse response,
+		@NonNull Object handler
+	) {
+		if (isAnnotationPresent(handler)) {
+			return true;
+		}
+
+		String accessToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (accessToken == null) {
+			throw new AuthException(NOT_INCLUDE_ACCESS_TOKEN);
+		}
+
+		jwtProvider.validateToken(accessToken);
+		return true;
+	}
+}

--- a/api/src/main/java/dev/handsup/common/config/WebConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/WebConfig.java
@@ -1,0 +1,31 @@
+package dev.handsup.common.config;
+
+import java.util.List;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import dev.handsup.auth.jwt.JwtAuthorizationArgumentResolver;
+import dev.handsup.auth.jwt.JwtInterceptor;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+	private final JwtAuthorizationArgumentResolver jwtAuthorizationArgumentResolver;
+	private final JwtInterceptor jwtInterceptor;
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+		argumentResolvers.add(jwtAuthorizationArgumentResolver);
+	}
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(jwtInterceptor)
+			.addPathPatterns("/api/**");
+	}
+}

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import dev.handsup.auth.annotation.NoAuth;
 import dev.handsup.user.dto.UserApiMapper;
 import dev.handsup.user.dto.JoinUserApiRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
@@ -23,7 +24,7 @@ public class UserApiController {
 
 	private final UserService userService;
 
-	// @NoAuth	//TODO 추후 구현
+	@NoAuth
 	@PostMapping("/api/users")
 	@Operation(summary = "회원가입 API", description = "회원가입을 한다")
 	@ApiResponse(useReturnTypeSchema = true)

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -5,7 +5,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
-import dev.handsup.user.dto.ApiUserMapper;
+import dev.handsup.user.dto.UserApiMapper;
 import dev.handsup.user.dto.JoinUserApiRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.JoinUserResponse;
@@ -30,7 +30,7 @@ public class UserApiController {
 	public ResponseEntity<JoinUserResponse> join(
 		final @Valid @RequestBody JoinUserApiRequest request
 	) {
-		JoinUserRequest joinUserRequest = ApiUserMapper.toJoinUserRequest(request);
+		JoinUserRequest joinUserRequest = UserApiMapper.toJoinUserRequest(request);
 		Long userId = userService.join(joinUserRequest);
 		return ResponseEntity.ok(new JoinUserResponse(userId));
 	}

--- a/api/src/main/java/dev/handsup/user/dto/UserApiMapper.java
+++ b/api/src/main/java/dev/handsup/user/dto/UserApiMapper.java
@@ -6,7 +6,7 @@ import dev.handsup.user.dto.request.JoinUserRequest;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
-public class ApiUserMapper {
+public class UserApiMapper {
 	public static JoinUserRequest toJoinUserRequest(JoinUserApiRequest request) {
 		return JoinUserRequest.of(
 			request.email(),

--- a/api/src/test/java/dev/handsup/auth/JwtAuthorizationArgumentResolverTest.java
+++ b/api/src/test/java/dev/handsup/auth/JwtAuthorizationArgumentResolverTest.java
@@ -1,0 +1,77 @@
+package dev.handsup.auth;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import dev.handsup.auth.jwt.JwtAuthorizationArgumentResolver;
+import dev.handsup.auth.service.JwtProvider;
+import dev.handsup.common.exception.NotFoundException;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+
+@DisplayName("[JwtAuthorizationArgumentResolver 테스트]")
+@ExtendWith(MockitoExtension.class)
+class JwtAuthorizationArgumentResolverTest {
+
+	@InjectMocks
+	private JwtAuthorizationArgumentResolver resolver;
+	@Mock
+	private UserService userService;
+	@Mock
+	private JwtProvider jwtProvider;
+	@Mock
+	private MethodParameter parameter;
+	@Mock
+	private ModelAndViewContainer mavContainer;
+	private final MockHttpServletRequest mockHttpServletRequest = new MockHttpServletRequest();
+	@Mock
+	private NativeWebRequest webRequest;
+	@Mock
+	private WebDataBinderFactory binderFactory;
+
+	@Test
+	@DisplayName("[토큰이 유효하면 User 엔티티를 반환한다]")
+	void shouldResolveArgumentWithValidToken() {
+		// given
+		User user = UserFixture.testUser(1L);
+		mockHttpServletRequest.addHeader(HttpHeaders.AUTHORIZATION, "validToken");
+		when(userService.getUserById(user.getId())).thenReturn(user);
+		when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(mockHttpServletRequest);
+		when(jwtProvider.getClaim("validToken")).thenReturn(user.getId());
+
+		// when
+		Object o = resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory);
+
+		// then
+		assertThat(o).isEqualTo(user);
+	}
+
+	@Test
+	@DisplayName("[요청이 없으면 예외를 던진다]")
+	void shouldThrowNotFoundExceptionWhenRequestMissing() {
+		// given
+		when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(null);
+
+		// when + then
+		assertThatThrownBy(() -> resolver.resolveArgument(parameter, mavContainer, webRequest, binderFactory))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessageContaining(NOT_FOUND_REQUEST.getMessage());
+	}
+
+}

--- a/api/src/test/java/dev/handsup/auth/JwtInterceptorTest.java
+++ b/api/src/test/java/dev/handsup/auth/JwtInterceptorTest.java
@@ -1,0 +1,82 @@
+package dev.handsup.auth;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.web.method.HandlerMethod;
+
+import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.auth.exception.AuthException;
+import dev.handsup.auth.jwt.JwtInterceptor;
+import dev.handsup.auth.service.JwtProvider;
+import jakarta.servlet.http.HttpServletResponse;
+
+@DisplayName("[JwtInterceptor 테스트]")
+@ExtendWith(MockitoExtension.class)
+class JwtInterceptorTest {
+
+	@InjectMocks
+	private JwtInterceptor jwtInterceptor;
+	@Mock
+	private JwtProvider jwtProvider;
+	private final MockHttpServletRequest request = new MockHttpServletRequest();
+	@Mock
+	private HttpServletResponse response;
+	@Mock
+	private HandlerMethod handlerMethod;
+
+	@Test
+	@DisplayName("[토큰이 없고 @NoAuth 있으면 -> 통과]")
+	void shouldPassWithoutTokenWhenNoAuthAnnotationIsPresent() {
+		// given, when
+		when(handlerMethod.getMethodAnnotation(NoAuth.class))
+			.thenReturn(mock(NoAuth.class));
+		// then
+		assertThat(jwtInterceptor.preHandle(request, response, handlerMethod))
+			.isTrue();
+	}
+
+	@Test
+	@DisplayName("[토큰이 유효하다면 -> 통과]")
+	void shouldPassWithValidToken() {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, "validToken");
+		// when
+		doNothing().when(jwtProvider).validateToken("validToken");
+		// then
+		assertThat(jwtInterceptor.preHandle(request, response, handlerMethod))
+			.isTrue();
+	}
+
+	@Test
+	@DisplayName("[토큰이 없고 @NoAuth 없으면 -> 실패]")
+	void shouldThrowExceptionWhenTokenIsMissing() {
+		assertThatThrownBy(() -> jwtInterceptor.preHandle(request, response, handlerMethod))
+			.isInstanceOf(AuthException.class)
+			.hasMessageContaining(NOT_INCLUDE_ACCESS_TOKEN.getMessage());
+	}
+
+	@Test
+	@DisplayName("[토큰이 유효하지 않고 @NoAuth 없으면 -> 실패]")
+	void shouldThrowExceptionWithInvalidToken() {
+		// given
+		request.addHeader(HttpHeaders.AUTHORIZATION, "invalidToken");
+		doThrow(new AuthException(TOKEN_EXPIRED))
+			.when(jwtProvider).validateToken("invalidToken");
+
+		// when, then
+		assertThatThrownBy(() -> jwtInterceptor.preHandle(request, response, handlerMethod))
+			.isInstanceOf(AuthException.class)
+			.hasMessageContaining(TOKEN_EXPIRED.getMessage());
+	}
+
+}

--- a/api/src/test/java/dev/handsup/auth/controller/AuthApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auth/controller/AuthApiControllerTest.java
@@ -1,0 +1,101 @@
+package dev.handsup.auth.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.springframework.http.MediaType.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.ResultActions;
+
+import dev.handsup.auth.dto.TokenReIssueApiRequest;
+import dev.handsup.auth.dto.request.AuthRequest;
+import dev.handsup.auth.dto.response.AuthResponse;
+import dev.handsup.auth.service.AuthService;
+import dev.handsup.common.support.ApiTestSupport;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.dto.request.JoinUserRequest;
+import dev.handsup.user.service.UserService;
+
+@DisplayName("[AuthApiController API 테스트]")
+class AuthApiControllerTest extends ApiTestSupport {
+	
+	@Autowired
+	private UserService userService;
+	@Autowired
+	private AuthService authService;
+	private AuthRequest authRequest;
+	private final User user = UserFixture.testUser(1L);
+
+	@BeforeEach
+	void setUp() {
+		JoinUserRequest joinUserRequest = JoinUserRequest.of(
+			user.getEmail(),
+			user.getPassword(),
+			user.getNickname(),
+			user.getAddress().getSi(),
+			user.getAddress().getGu(),
+			user.getAddress().getDong(),
+			user.getProfileImageUrl()
+		);
+		userService.join(joinUserRequest);
+		authRequest = new AuthRequest(user.getEmail(), user.getPassword());
+	}
+
+	@Test
+	@DisplayName("[로그인 API를 호출하면 토큰이 응답된다]")
+	void loginTest() throws Exception {
+		// when
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/login")
+				.contentType(APPLICATION_JSON)
+				.content(toJson(authRequest))
+		);
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(jsonPath("$.accessToken").exists())
+			.andExpect(jsonPath("$.refreshToken").exists());
+	}
+
+	@Test
+	@DisplayName("[토큰 재발급 API를 호출하면 새로운 엑세스 토큰이 응답된다]")
+	void reIssueAccessTokenTest() throws Exception {
+		// given
+		AuthResponse authResponse = authService.login(authRequest);
+		String refreshToken = authResponse.refreshToken();
+		TokenReIssueApiRequest tokenReIssueApiRequest = new TokenReIssueApiRequest(refreshToken);
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/token")
+				.contentType(APPLICATION_JSON)
+				.content(toJson(tokenReIssueApiRequest))
+		);
+
+		// then
+		actions.andExpect(status().isOk())
+			.andExpect(content().string(not(emptyOrNullString())));
+	}
+
+	@Test
+	@DisplayName("[로그아웃 API를 호출하면 200 OK 응답이 반환된다]")
+	void logoutTest() throws Exception {
+		// given
+		AuthResponse authResponse = authService.login(authRequest);
+		String accessToken = authResponse.accessToken();
+
+		// when
+		ResultActions actions = mockMvc.perform(
+			post("/api/auth/logout")
+				.header("Authorization", accessToken)
+		);
+
+		// then
+		actions.andExpect(status().isOk());
+	}
+}

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -9,3 +9,7 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.orm.jdbc.bind: trace
+
+jwt:
+  secret: prgrmsdevcoursehandsupjsonwebtokensecretkey202402
+  token-validity-in-seconds: 864000

--- a/core/src/main/java/dev/handsup/auth/domain/Auth.java
+++ b/core/src/main/java/dev/handsup/auth/domain/Auth.java
@@ -1,0 +1,45 @@
+package dev.handsup.auth.domain;
+
+import static jakarta.persistence.GenerationType.*;
+
+import dev.handsup.common.entity.TimeBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "auth_table")
+public class Auth extends TimeBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "auth_id")
+	private Long id;
+
+	@Column(name = "auth_user_id", nullable = false, unique = true)
+	private Long userId;
+
+	@Column(name = "auth_refresh_token", nullable = false, unique = true)
+	private String refreshToken;
+
+	@Builder
+	private Auth(Long userId, String refreshToken) {
+		this.userId = userId;
+		this.refreshToken = refreshToken;
+	}
+
+	public static Auth of(Long userId, String refreshToken) {
+		return Auth.builder()
+			.userId(userId)
+			.refreshToken(refreshToken)
+			.build();
+	}
+
+}

--- a/core/src/main/java/dev/handsup/auth/domain/BlacklistToken.java
+++ b/core/src/main/java/dev/handsup/auth/domain/BlacklistToken.java
@@ -1,0 +1,39 @@
+package dev.handsup.auth.domain;
+
+import static jakarta.persistence.GenerationType.*;
+
+import dev.handsup.common.entity.TimeBaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "blacklist_token")
+public class BlacklistToken extends TimeBaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = IDENTITY)
+	@Column(name = "blacklist_token_id")
+	private Long id;
+
+	@Column(name = "refresh_token", nullable = false, unique = true)
+	private String refreshToken;
+
+	@Builder
+	private BlacklistToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	public static BlacklistToken from(String refreshToken) {
+		return BlacklistToken.builder()
+			.refreshToken(refreshToken)
+			.build();
+	}
+}

--- a/core/src/main/java/dev/handsup/auth/dto/request/AuthRequest.java
+++ b/core/src/main/java/dev/handsup/auth/dto/request/AuthRequest.java
@@ -1,0 +1,19 @@
+package dev.handsup.auth.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+
+@Builder(access = AccessLevel.PRIVATE)
+public record AuthRequest(
+
+	String email,
+	String password
+) {
+	public static AuthRequest of(String email, String password) {
+		return AuthRequest.builder()
+			.email(email)
+			.password(password)
+			.build();
+	}
+
+}

--- a/core/src/main/java/dev/handsup/auth/dto/request/AuthRequest.java
+++ b/core/src/main/java/dev/handsup/auth/dto/request/AuthRequest.java
@@ -1,9 +1,11 @@
 package dev.handsup.auth.dto.request;
 
+import static lombok.AccessLevel.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = PRIVATE)
 public record AuthRequest(
 
 	String email,

--- a/core/src/main/java/dev/handsup/auth/dto/response/AuthResponse.java
+++ b/core/src/main/java/dev/handsup/auth/dto/response/AuthResponse.java
@@ -1,0 +1,16 @@
+package dev.handsup.auth.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AuthResponse(
+	String refreshToken,
+	String accessToken
+) {
+	public static AuthResponse of(String refreshToken, String accessToken) {
+		return AuthResponse.builder()
+			.refreshToken(refreshToken)
+			.accessToken(accessToken)
+			.build();
+	}
+}

--- a/core/src/main/java/dev/handsup/auth/exception/AuthErrorCode.java
+++ b/core/src/main/java/dev/handsup/auth/exception/AuthErrorCode.java
@@ -1,0 +1,25 @@
+package dev.handsup.auth.exception;
+
+import dev.handsup.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+	FAILED_LOGIN_BY_ANYTHING("등록되지 않은 아이디이거나 아이디 또는 비밀번호를 잘못 입력했습니다.", "AUTH_001"),
+	NOT_PERMITTED_USER("해당 요청에 대한 권한이 없습니다.", "AUTH_002"),
+	INVALID_TOKEN_ETC("기타 보안 문제로 토큰이 유효하지 못합니다.", "AUTH_003"),
+	NOT_FOUND_REFRESH_TOKEN("해당 리프레쉬 토큰의 인증 데이터가 존재하지 않습니다.", "AUTH_004"),
+	NOT_INCLUDE_ACCESS_TOKEN("요청에 액세스 토큰이 존재하지 않습니다.", "AUTH_005"),
+	NOT_FOUND_REQUEST("해당 요청이 존재하지 않습니다.", "AUTH_006"),
+	NOT_FOUND_USER_ID("해당 유저의 인증 데이터가 존재하지 않습니다.", "AUTH_007"),
+	TOKEN_EXPIRED("토큰이 만료 시간을 초과했습니다.", "AUTH_008"),
+	UNSUPPORTED_TOKEN("토큰 유형이 지원되지 않습니다.", "AUTH_010"),
+	MALFORMED_TOKEN("토큰의 구조가 올바르지 않습니다.", "AUTH_011"),
+	BLACKLISTED_TOKEN("해당 토큰은 블랙리스트에 등록되어있으므로 유효하지 않습니다.", "AUTH_012");
+
+	private final String message;
+	private final String code;
+}

--- a/core/src/main/java/dev/handsup/auth/exception/AuthException.java
+++ b/core/src/main/java/dev/handsup/auth/exception/AuthException.java
@@ -1,0 +1,15 @@
+package dev.handsup.auth.exception;
+
+import dev.handsup.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class AuthException extends RuntimeException {
+
+	private final String code;
+
+	public AuthException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.code = errorCode.getCode();
+	}
+}

--- a/core/src/main/java/dev/handsup/auth/repository/AuthRepository.java
+++ b/core/src/main/java/dev/handsup/auth/repository/AuthRepository.java
@@ -1,0 +1,20 @@
+package dev.handsup.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import dev.handsup.auth.domain.Auth;
+
+public interface AuthRepository extends JpaRepository<Auth, Long> {
+	Optional<Auth> findByRefreshToken(String refreshToken);
+
+	Optional<Auth> findByUserId(Long userId);
+
+	@Modifying
+	@Query("update Auth a SET a.refreshToken = :refreshToken where a.id = :id")
+	void updateRefreshToken(@Param("id") Long id, @Param("refreshToken") String refreshToken);
+}

--- a/core/src/main/java/dev/handsup/auth/repository/BlacklistTokenRepository.java
+++ b/core/src/main/java/dev/handsup/auth/repository/BlacklistTokenRepository.java
@@ -1,0 +1,9 @@
+package dev.handsup.auth.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import dev.handsup.auth.domain.BlacklistToken;
+
+public interface BlacklistTokenRepository extends JpaRepository<BlacklistToken, Long> {
+	boolean existsByRefreshToken(String refreshToken);
+}

--- a/core/src/main/java/dev/handsup/auth/service/AuthService.java
+++ b/core/src/main/java/dev/handsup/auth/service/AuthService.java
@@ -14,7 +14,7 @@ import dev.handsup.auth.dto.request.AuthRequest;
 import dev.handsup.auth.dto.response.AuthResponse;
 import dev.handsup.auth.exception.AuthException;
 import dev.handsup.auth.repository.AuthRepository;
-import dev.handsup.auth.repository.BlacklistRepository;
+import dev.handsup.auth.repository.BlacklistTokenRepository;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.service.UserService;
@@ -28,7 +28,7 @@ public class AuthService {
 	private final JwtProvider jwtProvider;
 	private final AuthRepository authRepository;
 	private final EncryptHelper encryptHelper;
-	private final BlacklistRepository blacklistRepository;
+	private final BlacklistTokenRepository blacklistTokenRepository;
 
 	private Auth getAuthByRefreshToken(String refreshToken) {
 		return authRepository.findByRefreshToken(refreshToken)
@@ -76,7 +76,7 @@ public class AuthService {
 
 		authRepository.findByUserId(user.getId()).ifPresentOrElse(
 			auth ->
-				blacklistRepository.save(
+				blacklistTokenRepository.save(
 					BlacklistToken.builder()
 						.refreshToken(auth.getRefreshToken())
 						.build()),
@@ -87,7 +87,7 @@ public class AuthService {
 	}
 
 	public String createAccessTokenByRefreshToken(String refreshToken) {
-		boolean isBlacklisted = blacklistRepository.existsByRefreshToken(refreshToken);
+		boolean isBlacklisted = blacklistTokenRepository.existsByRefreshToken(refreshToken);
 		if (isBlacklisted) {
 			throw new AuthException(BLACKLISTED_TOKEN);
 		}

--- a/core/src/main/java/dev/handsup/auth/service/AuthService.java
+++ b/core/src/main/java/dev/handsup/auth/service/AuthService.java
@@ -1,0 +1,100 @@
+package dev.handsup.auth.service;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import dev.handsup.auth.domain.Auth;
+import dev.handsup.auth.domain.BlacklistToken;
+import dev.handsup.auth.domain.EncryptHelper;
+import dev.handsup.auth.dto.request.AuthRequest;
+import dev.handsup.auth.dto.response.AuthResponse;
+import dev.handsup.auth.exception.AuthException;
+import dev.handsup.auth.repository.AuthRepository;
+import dev.handsup.auth.repository.BlacklistRepository;
+import dev.handsup.common.exception.NotFoundException;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+	private final UserService userService;
+	private final JwtProvider jwtProvider;
+	private final AuthRepository authRepository;
+	private final EncryptHelper encryptHelper;
+	private final BlacklistRepository blacklistRepository;
+
+	private Auth getAuthByRefreshToken(String refreshToken) {
+		return authRepository.findByRefreshToken(refreshToken)
+			.orElseThrow(() -> new NotFoundException(NOT_FOUND_REFRESH_TOKEN));
+	}
+
+	private AuthResponse saveAuth(Long userId) {
+		String refreshToken = jwtProvider.createRefreshToken(userId);
+		String accessToken = jwtProvider.createAccessToken(userId);
+		Optional<Auth> auth = authRepository.findByUserId(userId);
+
+		auth.ifPresentOrElse(
+			existingAuth -> authRepository.updateRefreshToken(existingAuth.getId(), refreshToken),
+			() -> {
+				Auth newAuth = Auth.builder()
+					.userId(userId)
+					.refreshToken(refreshToken)
+					.build();
+
+				authRepository.save(newAuth);
+			}
+		);
+
+		return AuthResponse.builder()
+			.refreshToken(refreshToken)
+			.accessToken(accessToken)
+			.build();
+	}
+
+	@Transactional
+	public AuthResponse login(AuthRequest authRequest) {
+		Long userId = userService.getUserByEmail(authRequest.email()).getId();
+		AuthResponse authResponse = saveAuth(userId);
+		String plainPassword = authRequest.password();
+		String hashedPassword = userService.getUserById(userId).getPassword();
+
+		if (encryptHelper.isMatch(plainPassword, hashedPassword)) {
+			return authResponse;
+		}
+		throw new NotFoundException(FAILED_LOGIN_BY_ANYTHING);
+	}
+
+	@Transactional
+	public void logout(User user) {
+
+		authRepository.findByUserId(user.getId()).ifPresentOrElse(
+			auth ->
+				blacklistRepository.save(
+					BlacklistToken.builder()
+						.refreshToken(auth.getRefreshToken())
+						.build()),
+			() -> {
+				throw new NotFoundException(NOT_FOUND_USER_ID);
+			}
+		);
+	}
+
+	public String createAccessTokenByRefreshToken(String refreshToken) {
+		boolean isBlacklisted = blacklistRepository.existsByRefreshToken(refreshToken);
+		if (isBlacklisted) {
+			throw new AuthException(BLACKLISTED_TOKEN);
+		}
+
+		Auth auth = getAuthByRefreshToken(refreshToken);
+		Long userId = userService.getUserById(auth.getUserId()).getId();
+		return jwtProvider.createAccessToken(userId);
+	}
+
+}

--- a/core/src/main/java/dev/handsup/auth/service/JwtProvider.java
+++ b/core/src/main/java/dev/handsup/auth/service/JwtProvider.java
@@ -1,0 +1,87 @@
+package dev.handsup.auth.service;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+
+import java.security.Key;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import dev.handsup.auth.exception.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@Component
+public class JwtProvider {
+
+	private final int tokenValidSeconds;
+	private final Key key;
+	private static final String USER_ID = "userId";
+
+	public JwtProvider(
+		@Value("${jwt.secret}") String secretKey,
+		@Value("${jwt.token-validity-in-seconds}") int tokenValidSeconds
+	) {
+		this.tokenValidSeconds = tokenValidSeconds;
+
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+	}
+
+	public Long getClaim(String token) {
+		Claims claimsBody = Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+
+		return Long.valueOf((Integer)claimsBody.get(USER_ID));
+	}
+
+	public String createAccessToken(Long userId) {
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setHeaderParam("type", "jwt")
+			.claim(USER_ID, userId)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + tokenValidSeconds * 1000L))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public String createRefreshToken(Long userId) {
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setHeaderParam("type", "jwt")
+			.claim(USER_ID, userId)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + tokenValidSeconds * 1000L * 30))
+			.signWith(key, SignatureAlgorithm.HS256)
+			.compact();
+	}
+
+	public void validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+		} catch (io.jsonwebtoken.ExpiredJwtException e) {
+			throw new AuthException(TOKEN_EXPIRED);
+		} catch (io.jsonwebtoken.UnsupportedJwtException e) {
+			throw new AuthException(UNSUPPORTED_TOKEN);
+		} catch (io.jsonwebtoken.MalformedJwtException e) {
+			throw new AuthException(MALFORMED_TOKEN);
+		} catch (Exception e) {
+			throw new AuthException(INVALID_TOKEN_ETC);
+		}
+	}
+
+}

--- a/core/src/main/java/dev/handsup/user/domain/User.java
+++ b/core/src/main/java/dev/handsup/user/domain/User.java
@@ -86,7 +86,7 @@ public class User extends TimeBaseEntity {
 		this.profileImageUrl = profileImageUrl;
 	}
 
-	@Builder(access = AccessLevel.PRIVATE)
+	@Builder
 	private User(
 		String email,
 		String password,

--- a/core/src/main/java/dev/handsup/user/dto/request/JoinUserRequest.java
+++ b/core/src/main/java/dev/handsup/user/dto/request/JoinUserRequest.java
@@ -1,9 +1,11 @@
 package dev.handsup.user.dto.request;
 
+import static lombok.AccessLevel.*;
+
 import lombok.AccessLevel;
 import lombok.Builder;
 
-@Builder(access = AccessLevel.PRIVATE)
+@Builder(access = PRIVATE)
 public record JoinUserRequest(
 
 	String email,

--- a/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
@@ -1,0 +1,108 @@
+package dev.handsup.auth.service;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.handsup.auth.domain.Auth;
+import dev.handsup.auth.domain.BlacklistToken;
+import dev.handsup.auth.domain.EncryptHelper;
+import dev.handsup.auth.dto.request.AuthRequest;
+import dev.handsup.auth.dto.response.AuthResponse;
+import dev.handsup.auth.repository.AuthRepository;
+import dev.handsup.auth.repository.BlacklistRepository;
+import dev.handsup.common.exception.NotFoundException;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.service.UserService;
+
+@DisplayName("[AuthService 테스트]")
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+	@InjectMocks
+	private AuthService authService;
+	@Mock
+	private AuthRepository authRepository;
+	@Mock
+	private UserService userService;
+	@Mock
+	private JwtProvider jwtProvider;
+	@Mock
+	private EncryptHelper encryptHelper;
+	@Mock
+	private BlacklistRepository blacklistRepository;
+
+	private User user = UserFixture.testUser(1L);
+	private AuthRequest authRequest = new AuthRequest(user.getEmail(), user.getPassword());
+
+	@Test
+	@DisplayName("[로그인 성공 시 토큰을 발급한다]")
+	void loginSuccessTest() {
+		// given
+		when(userService.getUserByEmail(authRequest.email())).thenReturn(user);
+		when(userService.getUserById(1L)).thenReturn(user);
+		when(encryptHelper.isMatch(anyString(), anyString())).thenReturn(true);
+		Auth anyAuth = new Auth();
+		when(authRepository.findByUserId(user.getId())).thenReturn(Optional.of(anyAuth));
+		when(jwtProvider.createAccessToken(anyLong())).thenReturn("access-token");
+		when(jwtProvider.createRefreshToken(anyLong())).thenReturn("refresh-token");
+
+		// when
+		AuthResponse authResponse = authService.login(authRequest);
+
+		// then
+		assertEquals("access-token", authResponse.accessToken());
+		assertEquals("refresh-token", authResponse.refreshToken());
+	}
+
+	@Test
+	@DisplayName("로그인 실패 시 예외를 던진다")
+	void loginFailTest() {
+		// given
+		when(userService.getUserByEmail(authRequest.email())).thenReturn(user);
+		when(userService.getUserById(1L)).thenReturn(user);
+		when(encryptHelper.isMatch(anyString(), anyString())).thenReturn(false);
+
+		// when & then
+		assertThrows(NotFoundException.class, () -> authService.login(authRequest));
+	}
+
+	@Test
+	@DisplayName("로그아웃 성공 시 블랙리스트에 토큰을 추가한다")
+	void logoutSuccessTest() {
+		// given
+		Long userId = 1L;
+		Auth auth = Auth.of(userId, "refresh-token");
+		when(authRepository.findByUserId(userId)).thenReturn(Optional.of(auth));
+
+		// when
+		authService.logout(user);
+
+		// then
+		verify(blacklistRepository).save(any(BlacklistToken.class));
+	}
+
+	@Test
+	@DisplayName("로그아웃 실패 시 NotFoundException을 던진다")
+	void logoutFailTest() {
+		// given
+		Long userId = 1L;
+		when(authRepository.findByUserId(userId)).thenReturn(Optional.empty());
+
+		// when & then
+		assertThatThrownBy(() -> authService.logout(user))
+			.isInstanceOf(NotFoundException.class)
+			.hasMessageContaining(NOT_FOUND_USER_ID.getMessage());
+	}
+}

--- a/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
@@ -20,7 +20,7 @@ import dev.handsup.auth.domain.EncryptHelper;
 import dev.handsup.auth.dto.request.AuthRequest;
 import dev.handsup.auth.dto.response.AuthResponse;
 import dev.handsup.auth.repository.AuthRepository;
-import dev.handsup.auth.repository.BlacklistRepository;
+import dev.handsup.auth.repository.BlacklistTokenRepository;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.fixture.UserFixture;
 import dev.handsup.user.domain.User;
@@ -41,7 +41,7 @@ class AuthServiceTest {
 	@Mock
 	private EncryptHelper encryptHelper;
 	@Mock
-	private BlacklistRepository blacklistRepository;
+	private BlacklistTokenRepository blacklistTokenRepository;
 
 	private User user = UserFixture.testUser(1L);
 	private AuthRequest authRequest = new AuthRequest(user.getEmail(), user.getPassword());
@@ -90,7 +90,7 @@ class AuthServiceTest {
 		authService.logout(user);
 
 		// then
-		verify(blacklistRepository).save(any(BlacklistToken.class));
+		verify(blacklistTokenRepository).save(any(BlacklistToken.class));
 	}
 
 	@Test

--- a/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
@@ -67,7 +67,7 @@ class AuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("로그인 실패 시 예외를 던진다")
+	@DisplayName("[로그인 실패 시 예외를 던진다]")
 	void loginFailTest() {
 		// given
 		when(userService.getUserByEmail(authRequest.email())).thenReturn(user);
@@ -79,7 +79,7 @@ class AuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("로그아웃 성공 시 블랙리스트에 토큰을 추가한다")
+	@DisplayName("[로그아웃 성공 시 블랙리스트에 토큰을 추가한다]")
 	void logoutSuccessTest() {
 		// given
 		Long userId = 1L;
@@ -94,7 +94,7 @@ class AuthServiceTest {
 	}
 
 	@Test
-	@DisplayName("로그아웃 실패 시 NotFoundException을 던진다")
+	@DisplayName("[로그아웃 실패 시 NotFoundException을 던진다]")
 	void logoutFailTest() {
 		// given
 		Long userId = 1L;

--- a/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
@@ -38,7 +38,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("Access Token을 성공적으로 만든다")
+	@DisplayName("[Access Token을 성공적으로 만든다]")
 	void createAccessTokenTest() {
 		// given
 		Long userId = 123L;
@@ -62,7 +62,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("Refresh Token을 성공적으로 만든다")
+	@DisplayName("[Refresh Token을 성공적으로 만든다]")
 	void createRefreshTokenTest() {
 		// given
 		Long userId = 123L;
@@ -86,7 +86,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("Claim 에서 UserId를 뽑아온다")
+	@DisplayName("[Claim 에서 UserId를 뽑아온다]")
 	void getClaimTest() {
 		// given
 		Long userId = 123L;
@@ -100,7 +100,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("유효성 검사에서 정상적인 토큰은 성공한다")
+	@DisplayName("[유효성 검사에서 정상적인 토큰은 성공한다]")
 	void validateValidTokenTest() {
 		// given
 		Long userId = 123L;
@@ -111,7 +111,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("유효성 검사에서 구조가 안 맞는 토큰은 실패한다")
+	@DisplayName("[유효성 검사에서 구조가 안 맞는 토큰은 실패한다]")
 	void validateInValidTokenTest() {
 		// given
 		String invalidToken = "invalidToken";
@@ -125,7 +125,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("유효성 검사에서 유효 기간이 지난 토큰은 실패한다")
+	@DisplayName("[유효성 검사에서 유효 기간이 지난 토큰은 실패한다]")
 	void validateExpiredTokenTest() {
 		// given
 		Long userId = 123L;
@@ -141,7 +141,7 @@ class JwtProviderTest {
 	}
 
 	@Test
-	@DisplayName("유효성 검사에서 잘못된 서명의 토큰은 실패한다")
+	@DisplayName("[유효성 검사에서 잘못된 서명의 토큰은 실패한다]")
 	void validateTokenWithAlteredSignatureTest() {
 		// given
 		Long userId = 123L;

--- a/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
@@ -1,0 +1,158 @@
+package dev.handsup.auth.service;
+
+import static dev.handsup.auth.exception.AuthErrorCode.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.security.Key;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import dev.handsup.auth.exception.AuthException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+
+@DisplayName("[JwtProvider 테스트]")
+@ExtendWith(MockitoExtension.class)
+class JwtProviderTest {
+
+	private JwtProvider jwtProvider;
+	private Key key;
+	private int tokenValidSeconds;
+	private String secretKey;
+
+	@BeforeEach
+	void setUp() {
+		secretKey = "fdflsjhflkwejfblkjhvuixochvuhsofiuesafbidsfab223411";
+		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+		this.key = Keys.hmacShaKeyFor(keyBytes);
+		tokenValidSeconds = 3600;
+		jwtProvider = new JwtProvider(secretKey, tokenValidSeconds);
+	}
+
+	@Test
+	@DisplayName("Access Token을 성공적으로 만든다")
+	void createAccessTokenTest() {
+		// given
+		Long userId = 123L;
+
+		// when
+		String token = jwtProvider.createAccessToken(userId);
+
+		Jws<Claims> claimsJws = Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token);
+		Claims claims = claimsJws.getBody();
+
+		// then
+		assertThat(token).isNotNull();
+		assertThat(userId).isEqualTo(claims.get("userId", Long.class));
+		assertThat(claims.getIssuedAt()).isNotNull();
+		assertThat(claims.getExpiration()).isNotNull();
+		assertThat(claims.getExpiration().getTime() - claims.getIssuedAt().getTime())
+			.isCloseTo(tokenValidSeconds * 1000L, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
+	}
+
+	@Test
+	@DisplayName("Refresh Token을 성공적으로 만든다")
+	void createRefreshTokenTest() {
+		// given
+		Long userId = 123L;
+
+		// when
+		String token = jwtProvider.createRefreshToken(userId);
+
+		Jws<Claims> claimsJws = Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token);
+		Claims claims = claimsJws.getBody();
+
+		// then
+		assertThat(token).isNotNull();
+		assertThat(userId).isEqualTo(claims.get("userId", Long.class));
+		assertThat(claims.getIssuedAt()).isNotNull();
+		assertThat(claims.getExpiration()).isNotNull();
+		assertThat(claims.getExpiration().getTime() - claims.getIssuedAt().getTime())
+			.isCloseTo(tokenValidSeconds * 1000L * 30, within(1000L));    // 토큰 생성 자체에 드는 시간 고려
+	}
+
+	@Test
+	@DisplayName("Claim 에서 UserId를 뽑아온다")
+	void getClaimTest() {
+		// given
+		Long userId = 123L;
+		String token = jwtProvider.createAccessToken(userId);
+
+		// when
+		Long extractedUserId = jwtProvider.getClaim(token);
+
+		// then
+		assertThat(extractedUserId).isEqualTo(userId);
+	}
+
+	@Test
+	@DisplayName("유효성 검사에서 정상적인 토큰은 성공한다")
+	void validateValidTokenTest() {
+		// given
+		Long userId = 123L;
+		String validToken = jwtProvider.createAccessToken(userId);
+
+		// when, then
+		assertDoesNotThrow(() -> jwtProvider.validateToken(validToken));
+	}
+
+	@Test
+	@DisplayName("유효성 검사에서 구조가 안 맞는 토큰은 실패한다")
+	void validateInValidTokenTest() {
+		// given
+		String invalidToken = "invalidToken";
+
+		// when, then
+		assertThatThrownBy(
+			() -> jwtProvider.validateToken(invalidToken)
+		)
+			.isInstanceOf(AuthException.class)
+			.hasMessageContaining(MALFORMED_TOKEN.getMessage());
+	}
+
+	@Test
+	@DisplayName("유효성 검사에서 유효 기간이 지난 토큰은 실패한다")
+	void validateExpiredTokenTest() {
+		// given
+		Long userId = 123L;
+		jwtProvider = new JwtProvider(secretKey, -1000000);
+		String expiredToken = jwtProvider.createAccessToken(userId);
+
+		// when, then
+		assertThatThrownBy(
+			() -> jwtProvider.validateToken(expiredToken)
+		)
+			.isInstanceOf(AuthException.class)
+			.hasMessageContaining(TOKEN_EXPIRED.getMessage());
+	}
+
+	@Test
+	@DisplayName("유효성 검사에서 잘못된 서명의 토큰은 실패한다")
+	void validateTokenWithAlteredSignatureTest() {
+		// given
+		Long userId = 123L;
+		String validToken = jwtProvider.createAccessToken(userId);
+		String alteredToken = validToken.substring(0, validToken.length() - 4) + "abcd";
+
+		// when, then
+		assertThatThrownBy(
+			() -> jwtProvider.validateToken(alteredToken)
+		)
+			.isInstanceOf(AuthException.class)
+			.hasMessageContaining(INVALID_TOKEN_ETC.getMessage());
+	}
+}

--- a/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/JwtProviderTest.java
@@ -27,6 +27,7 @@ class JwtProviderTest {
 	private Key key;
 	private int tokenValidSeconds;
 	private String secretKey;
+	private final Long userId = 123L;
 
 	@BeforeEach
 	void setUp() {
@@ -40,9 +41,6 @@ class JwtProviderTest {
 	@Test
 	@DisplayName("[Access Token을 성공적으로 만든다]")
 	void createAccessTokenTest() {
-		// given
-		Long userId = 123L;
-
 		// when
 		String token = jwtProvider.createAccessToken(userId);
 
@@ -64,9 +62,6 @@ class JwtProviderTest {
 	@Test
 	@DisplayName("[Refresh Token을 성공적으로 만든다]")
 	void createRefreshTokenTest() {
-		// given
-		Long userId = 123L;
-
 		// when
 		String token = jwtProvider.createRefreshToken(userId);
 
@@ -89,7 +84,6 @@ class JwtProviderTest {
 	@DisplayName("[Claim 에서 UserId를 뽑아온다]")
 	void getClaimTest() {
 		// given
-		Long userId = 123L;
 		String token = jwtProvider.createAccessToken(userId);
 
 		// when
@@ -103,7 +97,6 @@ class JwtProviderTest {
 	@DisplayName("[유효성 검사에서 정상적인 토큰은 성공한다]")
 	void validateValidTokenTest() {
 		// given
-		Long userId = 123L;
 		String validToken = jwtProvider.createAccessToken(userId);
 
 		// when, then
@@ -128,7 +121,6 @@ class JwtProviderTest {
 	@DisplayName("[유효성 검사에서 유효 기간이 지난 토큰은 실패한다]")
 	void validateExpiredTokenTest() {
 		// given
-		Long userId = 123L;
 		jwtProvider = new JwtProvider(secretKey, -1000000);
 		String expiredToken = jwtProvider.createAccessToken(userId);
 
@@ -144,7 +136,6 @@ class JwtProviderTest {
 	@DisplayName("[유효성 검사에서 잘못된 서명의 토큰은 실패한다]")
 	void validateTokenWithAlteredSignatureTest() {
 		// given
-		Long userId = 123L;
 		String validToken = jwtProvider.createAccessToken(userId);
 		String alteredToken = validToken.substring(0, validToken.length() - 4) + "abcd";
 

--- a/core/src/test/java/dev/handsup/user/service/UserServiceTest.java
+++ b/core/src/test/java/dev/handsup/user/service/UserServiceTest.java
@@ -84,7 +84,7 @@ class UserServiceTest {
 		given(encryptHelper.encrypt(request.password()))
 			.willReturn("encryptedPassword");
 
-		User savedUser = UserFixture.user(1L);
+		User savedUser = UserFixture.testUser(1L);
 		given(userRepository.save(any(User.class)))
 			.willReturn(savedUser);
 

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -9,3 +9,7 @@ spring:
 logging.level:
   org.hibernate.SQL: debug
   org.hibernate.orm.jdbc.bind: trace
+
+jwt:
+  secret: prgrmsdevcoursehandsupjsonwebtokensecretkey202402
+  token-validity-in-seconds: 864000

--- a/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
@@ -9,10 +9,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class UserFixture {
 
-	static final String email = "hello123@naver.com";
-	static final String password = "password123";
-	static final String nickname = "nickname123";
-	static final String profileImageUrl =
+	static final String EMAIL = "hello123@naver.com";
+	static final String PASSWORD = "password123";
+	static final String NICKNAME = "nickname123";
+	static final String PROFILE_IMAGE_URL =
 		"https://lh3.googleusercontent.com/a/ACg8ocI5mIsHlnobowJ34VO9ZN8G31hlB4OBBRo_JoWItp5Vyg=s288-c-no";
 	static final Address address = Address.builder()
 		.si("서울시")
@@ -21,16 +21,10 @@ public final class UserFixture {
 		.build();
 
 	public static User user() {
-		return User.of(
-			email,
-			password,
-			nickname,
-			address,
-			profileImageUrl
-			);
+		return User.of(EMAIL, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
 	}
 
-	public static User user(Long id) {
-		return User.getTestUser(id, email, password, nickname, address, profileImageUrl);
+	public static User testUser(Long id) {
+		return User.getTestUser(id, EMAIL, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
 	}
 }


### PR DESCRIPTION
close #3 
### 📑 작업 상세 내용

- `@NoAuth` 를 인증이 필요하지 않은 Api 의 클래스레벨에 붙혀줍니다.
- 인증이 필요한 Api 는 그대로 두면 됩니다.
- 사용자가 Request Body 에 `accessToken` 을 담아서 Api 요청하는 경우, 요청 파라미터에 `@JwtAuthorization User` 를 넣어줍시다.
- 그러면 사용자의 Token 에 해당하는 User 엔티티를 찾아줍니다.

### 💫 작업 요약

- JWT 인증 인가 세팅

### 🔍 중점적으로 리뷰 할 부분

- 인증과 인가 관련한 개선 사항이 있는지
- 사용법에 대한 질문