### PR TITLE
[feat] : 이미지 업로드 구현

### DIFF
--- a/api/src/main/java/dev/handsup/image/controller/ImageController.java
+++ b/api/src/main/java/dev/handsup/image/controller/ImageController.java
@@ -8,10 +8,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import dev.handsup.auth.annotation.NoAuth;
 import dev.handsup.image.dto.UploadImagesRequest;
 import dev.handsup.image.dto.UploadImagesResponse;
 import dev.handsup.image.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -21,7 +22,8 @@ import lombok.RequiredArgsConstructor;
 public class ImageController {
 	private final S3Service s3Service;
 
-	@NoAuth
+	@Operation(summary = "이미지 파일 리스트 전송 API", description = "이미지 파일을 전송하고 URL을 반환받는다.")
+	@ApiResponse(useReturnTypeSchema = true)
 	@PostMapping
 	public ResponseEntity<UploadImagesResponse> uploadImages(
 		@ModelAttribute @Valid UploadImagesRequest uploadImagesRequest

--- a/api/src/main/java/dev/handsup/image/controller/ImageController.java
+++ b/api/src/main/java/dev/handsup/image/controller/ImageController.java
@@ -1,0 +1,32 @@
+package dev.handsup.image.controller;
+
+import java.util.List;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.image.dto.UploadImagesRequest;
+import dev.handsup.image.dto.UploadImagesResponse;
+import dev.handsup.image.service.S3Service;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/images")
+public class ImageController {
+	private final S3Service s3Service;
+
+	@NoAuth
+	@PostMapping
+	public ResponseEntity<UploadImagesResponse> uploadImages(
+		@ModelAttribute @Valid UploadImagesRequest uploadImagesRequest
+	) {
+		List<String> imgUrls = s3Service.uploadImages(uploadImagesRequest.images());
+		return ResponseEntity.ok(UploadImagesResponse.from(imgUrls));
+	}
+}

--- a/api/src/main/java/dev/handsup/image/dto/UploadImagesRequest.java
+++ b/api/src/main/java/dev/handsup/image/dto/UploadImagesRequest.java
@@ -11,4 +11,5 @@ public record UploadImagesRequest(
 	@NotNull(message = "이미지는 필수 입력 항목입니다.")
 	@Size(min = 1, max = 10, message = "이미지는 1장 이상 10장 이하로 선택하세요.")
 	List<MultipartFile> images
-){}
+) {
+}

--- a/api/src/main/java/dev/handsup/image/dto/UploadImagesRequest.java
+++ b/api/src/main/java/dev/handsup/image/dto/UploadImagesRequest.java
@@ -1,0 +1,14 @@
+package dev.handsup.image.dto;
+
+import java.util.List;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record UploadImagesRequest(
+	@NotNull(message = "이미지는 필수 입력 항목입니다.")
+	@Size(min = 1, max = 10, message = "이미지는 1장 이상 10장 이하로 선택하세요.")
+	List<MultipartFile> images
+){}

--- a/api/src/main/java/dev/handsup/image/dto/UploadImagesResponse.java
+++ b/api/src/main/java/dev/handsup/image/dto/UploadImagesResponse.java
@@ -1,0 +1,11 @@
+package dev.handsup.image.dto;
+
+import java.util.List;
+
+public record UploadImagesResponse(
+	List<String> imageUrls
+) {
+	public static UploadImagesResponse from(List<String> imageUrls) {
+		return new UploadImagesResponse(imageUrls);
+	}
+}

--- a/api/src/test/resources/application.yml
+++ b/api/src/test/resources/application.yml
@@ -13,3 +13,14 @@ logging.level:
 jwt:
   secret: prgrmsdevcoursehandsupjsonwebtokensecretkeytest123
   token-validity-in-seconds: 864000
+cloud:
+  aws:
+    credentials:
+      access-key: s3-access-key
+      secret-key: s3-secret-key
+    region:
+      static: s3-region
+    s3:
+      bucket: s3-bucket-name
+    stack:
+      auto: false

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -33,6 +33,9 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //s3
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 // Querydsl

--- a/core/src/main/java/dev/handsup/common/config/S3Config.java
+++ b/core/src/main/java/dev/handsup/common/config/S3Config.java
@@ -1,0 +1,33 @@
+package dev.handsup.common.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+
+@Configuration
+public class S3Config {
+
+	@Value("${cloud.aws.credentials.access-key}")
+	private String accessKey;
+
+	@Value("${cloud.aws.credentials.secret-key}")
+	private String secretKey;
+
+	@Value("${cloud.aws.region.static}")
+	private String region;
+
+	@Bean
+	public AmazonS3 amazonS3Client() {
+		AWSCredentials awsCredentials = new BasicAWSCredentials(accessKey, secretKey);
+		return AmazonS3ClientBuilder.standard()
+			.withRegion(region)
+			.withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+			.build();
+	}
+}

--- a/core/src/main/java/dev/handsup/image/exception/ImageErrorCode.java
+++ b/core/src/main/java/dev/handsup/image/exception/ImageErrorCode.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ImageErrorCode implements ErrorCode {
 
-	INVALID_FILE_NAME("파일명이 공백입니다.", "IMG_001"),
+	EMPTY_FILE_NAME("원본 파일명이 공백입니다.", "IMG_001"),
 	INVALID_FILE_EXTENSION("잘못된 파일 형식입니다.", "IMG_002"),
 	FAILED_TO_UPLOAD("s3에 이미지를 업로드하는데 실패했습니다.", "IMG_003"),
 	FAILED_TO_REMOVE("s3에서 이미지를 제거하는데 실패했습니다.", "IMG_004");

--- a/core/src/main/java/dev/handsup/image/exception/ImageErrorCode.java
+++ b/core/src/main/java/dev/handsup/image/exception/ImageErrorCode.java
@@ -1,0 +1,18 @@
+package dev.handsup.image.exception;
+
+import dev.handsup.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+
+	INVALID_FILE_NAME("파일명이 공백입니다.", "IMG_001"),
+	INVALID_FILE_EXTENSION("잘못된 파일 형식입니다.", "IMG_002"),
+	FAILED_TO_UPLOAD("s3에 이미지를 업로드하는데 실패했습니다.", "IMG_003"),
+	FAILED_TO_REMOVE("s3에서 이미지를 제거하는데 실패했습니다.", "IMG_004");
+
+	private final String message;
+	private final String code;
+}

--- a/core/src/main/java/dev/handsup/image/service/S3Service.java
+++ b/core/src/main/java/dev/handsup/image/service/S3Service.java
@@ -25,14 +25,12 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class S3Service {
-	@Value("${cloud.aws.s3.bucket}")
-	private String bucket;
-
-	private final AmazonS3 amazonS3;
 	private static final String s3FolderName = "images";
-
 	private static final List<String> FILE_EXTENSIONS = List.of(".jpg", ".jpeg", ".png", ".JPG",
 		".JPEG", ".PNG", ".webp", ".WEBP");
+	private final AmazonS3 amazonS3;
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
 
 	public List<String> uploadImages(List<MultipartFile> multipartFileList) {
 		ObjectMetadata objectMetadata = new ObjectMetadata();

--- a/core/src/main/java/dev/handsup/image/service/S3Service.java
+++ b/core/src/main/java/dev/handsup/image/service/S3Service.java
@@ -1,0 +1,85 @@
+package dev.handsup.image.service;
+
+import static java.util.Objects.*;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+
+import dev.handsup.common.exception.ValidationException;
+import dev.handsup.image.exception.ImageErrorCode;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+	@Value("${cloud.aws.s3.bucket}")
+	private String bucket;
+
+	private final AmazonS3 amazonS3;
+	private static final String s3FolderName = "images";
+
+	private static final List<String> FILE_EXTENSIONS = List.of(".jpg", ".jpeg", ".png", ".JPG",
+		".JPEG", ".PNG", ".webp", ".WEBP");
+
+	public List<String> uploadImages(List<MultipartFile> multipartFileList) {
+		ObjectMetadata objectMetadata = new ObjectMetadata();
+		List<String> imageUrls = new ArrayList<>();
+
+		for (MultipartFile multipartFile : multipartFileList) {
+			String fileName = createFileName(multipartFile.getOriginalFilename());
+			objectMetadata.setContentLength(multipartFile.getSize());
+			objectMetadata.setContentType(multipartFile.getContentType());
+
+			try (InputStream inputStream = multipartFile.getInputStream()) {
+				amazonS3.putObject(
+					new PutObjectRequest(bucket + "/" + s3FolderName, fileName, inputStream,
+						objectMetadata)
+						.withCannedAcl(CannedAccessControlList.PublicRead)
+				);
+				imageUrls.add(amazonS3.getUrl(bucket + "/" + s3FolderName, fileName).toString());
+			} catch (IOException exception) {
+				throw new ValidationException(ImageErrorCode.FAILED_TO_UPLOAD);
+			}
+		}
+		return imageUrls;
+	}
+
+	public void deleteImages(List<String> imageUrls) {
+		try {
+			imageUrls.forEach(
+				imageUrl -> amazonS3.deleteObject(bucket + "/" + s3FolderName, imageUrl)
+			);
+		} catch (SdkClientException exception) {
+			throw new ValidationException(ImageErrorCode.FAILED_TO_REMOVE);
+		}
+	}
+
+	private String createFileName(String fileName) {
+		return UUID.randomUUID().toString().concat(getFileExtension(fileName));
+	}
+
+	private String getFileExtension(String fileName) {
+		if (isNull(fileName) || fileName.isBlank()) {
+			throw new ValidationException(ImageErrorCode.INVALID_FILE_NAME);
+		}
+
+		String extension = fileName.substring(fileName.lastIndexOf("."));
+		if (!FILE_EXTENSIONS.contains(extension)) {
+			throw new ValidationException(ImageErrorCode.INVALID_FILE_EXTENSION);
+		}
+		return extension;
+	}
+}

--- a/core/src/main/java/dev/handsup/image/service/S3Service.java
+++ b/core/src/main/java/dev/handsup/image/service/S3Service.java
@@ -73,7 +73,7 @@ public class S3Service {
 
 	private String getFileExtension(String fileName) {
 		if (isNull(fileName) || fileName.isBlank()) {
-			throw new ValidationException(ImageErrorCode.INVALID_FILE_NAME);
+			throw new ValidationException(ImageErrorCode.EMPTY_FILE_NAME);
 		}
 
 		String extension = fileName.substring(fileName.lastIndexOf("."));

--- a/core/src/test/java/dev/handsup/image/service/S3ServiceTest.java
+++ b/core/src/test/java/dev/handsup/image/service/S3ServiceTest.java
@@ -1,0 +1,113 @@
+package dev.handsup.image.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import com.amazonaws.services.s3.AmazonS3;
+
+import dev.handsup.common.exception.ValidationException;
+import dev.handsup.image.exception.ImageErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+	@Mock
+	private AmazonS3 amazonS3;
+
+	@InjectMocks
+	private S3Service s3Service;
+
+	@BeforeEach
+	void setUp() {
+		ReflectionTestUtils.setField(s3Service, "bucket", "bucket-name");
+	}
+
+	@DisplayName("[이미지를 s3에 업로드하고 url을 반환받을 수 있다.]")
+	@Test
+	void uploadImages() {
+	    //given
+		MockMultipartFile file1 = new MockMultipartFile("file1", "test1.jpg", "image/jpeg",
+			"file content".getBytes());
+		MockMultipartFile file2 = new MockMultipartFile("file2", "test2.jpg", "image/jpeg",
+			"file content".getBytes());
+		String expectedUri = "https://aws.com/bucket-name/images/";
+
+		given(amazonS3.getUrl(any(), any()))
+			.willAnswer(invocation -> {
+				String bucketName = invocation.getArgument(0);
+				String fileName = invocation.getArgument(1);
+				System.out.println("fileName = " + fileName);
+				return new java.net.URL("https", "aws.com",
+					"/" + bucketName + "/" + fileName);
+			});
+
+	    //when
+		List<String> uploadedUrls = s3Service.uploadImages(List.of(file1, file2));
+
+	    //then
+		assertAll(
+			() -> assertThat(uploadedUrls).hasSize(2),
+			() -> assertThat(uploadedUrls.get(0)).contains(expectedUri),
+			() -> assertThat(uploadedUrls.get(1)).contains(expectedUri)
+		);
+	}
+
+
+
+	@DisplayName("[이미지 파일 확장자가 유효하지 않을 경우, 예외를 반환한다.]")
+	@Test
+	void uploadImages_fail() {
+	    //given
+		MockMultipartFile file = new MockMultipartFile("file1", "test1.wow", "image/jpeg",
+			"file content".getBytes());
+
+		//when, then
+		assertThatThrownBy(() -> s3Service.uploadImages(List.of(file)))
+			.isInstanceOf(ValidationException.class)
+			.hasMessageContaining(ImageErrorCode.INVALID_FILE_EXTENSION.getMessage());
+	}
+
+	@DisplayName("[원본 파일 이름이 0일 경우, 예외를 반환한다.]")
+	@Test
+	void uploadImages_fail2() {
+		//given
+		MockMultipartFile file = new MockMultipartFile("file1", "", "image/jpeg",
+			"file content".getBytes());
+
+		//when, then
+		assertThatThrownBy(() -> s3Service.uploadImages(List.of(file)))
+			.isInstanceOf(ValidationException.class)
+			.hasMessageContaining(ImageErrorCode.EMPTY_FILE_NAME.getMessage());
+	}
+
+	@DisplayName("[업로드된 이미지를 각각 삭제할 수 있다.]")
+	@Test
+	void deleteImages() {
+	    //given
+	    List<String> imageUrlsToDelete = List.of(
+			"https://example.com/bucket-name/images/random-uuid.jpg",
+			"https://example.com/bucket-name/images/random-uuid.jpg"
+		);
+
+	    //when
+	    s3Service.deleteImages(imageUrlsToDelete);
+
+	    //then
+		verify(amazonS3, times(imageUrlsToDelete.size())).deleteObject(any(), any()); // url 개수만큼 메서드 호출 보장
+	}
+
+
+}

--- a/core/src/test/java/dev/handsup/image/service/S3ServiceTest.java
+++ b/core/src/test/java/dev/handsup/image/service/S3ServiceTest.java
@@ -38,7 +38,7 @@ class S3ServiceTest {
 	@DisplayName("[이미지를 s3에 업로드하고 url을 반환받을 수 있다.]")
 	@Test
 	void uploadImages() {
-	    //given
+		//given
 		MockMultipartFile file1 = new MockMultipartFile("file1", "test1.jpg", "image/jpeg",
 			"file content".getBytes());
 		MockMultipartFile file2 = new MockMultipartFile("file2", "test2.jpg", "image/jpeg",
@@ -54,10 +54,10 @@ class S3ServiceTest {
 					"/" + bucketName + "/" + fileName);
 			});
 
-	    //when
+		//when
 		List<String> uploadedUrls = s3Service.uploadImages(List.of(file1, file2));
 
-	    //then
+		//then
 		assertAll(
 			() -> assertThat(uploadedUrls).hasSize(2),
 			() -> assertThat(uploadedUrls.get(0)).contains(expectedUri),
@@ -65,12 +65,10 @@ class S3ServiceTest {
 		);
 	}
 
-
-
 	@DisplayName("[이미지 파일 확장자가 유효하지 않을 경우, 예외를 반환한다.]")
 	@Test
 	void uploadImages_fail() {
-	    //given
+		//given
 		MockMultipartFile file = new MockMultipartFile("file1", "test1.wow", "image/jpeg",
 			"file content".getBytes());
 
@@ -96,18 +94,17 @@ class S3ServiceTest {
 	@DisplayName("[업로드된 이미지를 각각 삭제할 수 있다.]")
 	@Test
 	void deleteImages() {
-	    //given
-	    List<String> imageUrlsToDelete = List.of(
+		//given
+		List<String> imageUrlsToDelete = List.of(
 			"https://example.com/bucket-name/images/random-uuid.jpg",
 			"https://example.com/bucket-name/images/random-uuid.jpg"
 		);
 
-	    //when
-	    s3Service.deleteImages(imageUrlsToDelete);
+		//when
+		s3Service.deleteImages(imageUrlsToDelete);
 
-	    //then
+		//then
 		verify(amazonS3, times(imageUrlsToDelete.size())).deleteObject(any(), any()); // url 개수만큼 메서드 호출 보장
 	}
-
 
 }

--- a/core/src/test/resources/application.yml
+++ b/core/src/test/resources/application.yml
@@ -13,3 +13,14 @@ logging.level:
 jwt:
   secret: prgrmsdevcoursehandsupjsonwebtokensecretkeytest123
   token-validity-in-seconds: 864000
+cloud:
+  aws:
+    credentials:
+      access-key: s3-access-key
+      secret-key: s3-secret-key
+    region:
+      static: s3-region
+    s3:
+      bucket: s3-bucket-name
+    stack:
+      auto: false


### PR DESCRIPTION
close #44 
### 📑 작업 상세 내용
- application.yml s3 인증 부분 추가 (->노션 업데이트)
  - test application.yml에서 value 주입용 더미 데이터 추가 
- s3 설정 추가
- Image controller 및 s3 service 추가
  - 이미지 파일을 담아 이미지 업로드 API를 호출하면 S3에 저장하고 Url을 반환받는 방식입니다.

### 💫 작업 요약
- 이미지 업로드 API 구현
- s3Service 단위 테스트

### 🔍 중점적으로 리뷰 할 부분
- s3에 저장하는 로직은 보안 이슈도 있고 매번 값을 넣을 수 없어서, 통합 테스트 대신 직접 포스트맨으로 확인했습니다