### PR TITLE
[feat] : 경매 추천 API

### DIFF
--- a/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
+++ b/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
@@ -55,7 +55,7 @@ public class AuctionApiController {
 	}
 
 	@NoAuth
-	@Operation(summary = "메인 페이지 추천 API", description = "정렬 조건에 따라 경매를 추천한다.")
+	@Operation(summary = "경매 추천 API", description = "정렬 조건에 따라 경매를 추천한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/recommend")
 	public ResponseEntity<PageResponse<RecommendAuctionResponse>> getRecommendAuctions(

--- a/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
+++ b/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
@@ -1,18 +1,22 @@
 package dev.handsup.auction.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.handsup.auction.dto.request.RegisterAuctionRequest;
 import dev.handsup.auction.dto.response.AuctionDetailResponse;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.service.AuctionService;
 import dev.handsup.auth.annotation.NoAuth;
 import dev.handsup.auth.jwt.JwtAuthorization;
+import dev.handsup.common.dto.PageResponse;
 import dev.handsup.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -47,6 +51,20 @@ public class AuctionApiController {
 	@GetMapping("/{auctionId}")
 	public ResponseEntity<AuctionDetailResponse> getAuctionDetail(@PathVariable("auctionId") Long auctionId) {
 		AuctionDetailResponse response = auctionService.getAuctionDetail(auctionId);
+		return ResponseEntity.ok(response);
+	}
+
+	@NoAuth
+	@Operation(summary = "메인 페이지 추천 API", description = "정렬 조건에 따라 경매를 추천한다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/recommend")
+	public ResponseEntity<PageResponse<RecommendAuctionResponse>> getRecommendAuctions(
+		@RequestParam(value = "si", required = false) String si,
+		@RequestParam(value = "gu", required = false) String gu,
+		@RequestParam(value = "dong", required = false) String dong,
+		Pageable pageable
+	) {
+		PageResponse<RecommendAuctionResponse> response = auctionService.getRecommendAuctions(si, gu, dong, pageable);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.auction_field.PurchaseTime;
@@ -139,5 +140,73 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.gu").value(auction.getTradingLocation().getGu()))
 			.andExpect(jsonPath("$.dong").value(auction.getTradingLocation().getDong()))
 			.andExpect(jsonPath("$.bookmarkCount").value(auction.getBookmarkCount()));
+	}
+
+	@DisplayName("[정렬 조건과 지역 필터에 따라 경매글 목록을 반환한다.]")
+	@Test
+	void getRecommendAuctionsWithFilter() throws Exception {
+		//given
+		String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
+		Auction auction1 = AuctionFixture.auction(productCategory, "2024-03-11",si, gu, dong1);
+		Auction auction2 = AuctionFixture.auction(productCategory, "2024-03-07", si, gu, dong1);
+		Auction auction3 = AuctionFixture.auction(productCategory, "2024-03-08", si, gu, dong2);
+		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
+
+		//when
+		mockMvc.perform(get("/api/auctions/recommend")
+				.param("sort", "마감일")
+				.param("si", si)
+				.param("gu", gu)
+				.param("dong", dong1)
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size").value(2))
+			.andExpect(jsonPath("$.content[0].auctionId").value(auction2.getId()))
+			.andExpect(jsonPath("$.content[0].createdAt").value(auction2.getCreatedAt().toString()))
+			.andExpect(jsonPath("$.content[1].auctionId").value(auction1.getId()))
+			.andExpect(jsonPath("$.content[1].createdAt").value(auction1.getCreatedAt().toString()))
+			.andExpect(jsonPath("$.hasNext").value(false));
+	}
+
+	@DisplayName("[정렬 조건에 따라 경매글 목록을 반환한다.]")
+	@Test
+	void getRecommendAuctionsWithOutFilter() throws Exception {
+		//given
+		Auction auction1 = AuctionFixture.auction(productCategory);
+		Auction auction2 = AuctionFixture.auction(productCategory);
+		Auction auction3 = AuctionFixture.auction(productCategory);
+		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
+
+		//when
+		mockMvc.perform(get("/api/auctions/recommend")
+				.param("sort", "최근생성")
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size").value(3))
+			.andExpect(jsonPath("$.content[0].auctionId").value(auction3.getId()))
+			.andExpect(jsonPath("$.content[1].auctionId").value(auction2.getId()))
+			.andExpect(jsonPath("$.content[2].auctionId").value(auction1.getId()))
+			.andExpect(jsonPath("$.hasNext").value(false));
+	}
+
+	@DisplayName("[정렬 조건이 없을 시 예외를 반환한다.]")
+	@Test
+	void getRecommendAuctions_fails() throws Exception {
+		mockMvc.perform(get("/api/auctions/recommend")
+				.contentType(APPLICATION_JSON))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(jsonPath("$.message").value(AuctionErrorCode.EMPTY_SORT_INPUT.getMessage()))
+			.andExpect(jsonPath("$.code").value(AuctionErrorCode.EMPTY_SORT_INPUT.getCode()));
+	}
+
+	@DisplayName("[정렬 조건이 잘못되면 예외를 반환한다.]")
+	@Test
+	void getRecommendAuctions_fails2() throws Exception {
+		mockMvc.perform(get("/api/auctions/recommend")
+				.contentType(APPLICATION_JSON)
+				.param("sort", "NAN"))
+			.andDo(MockMvcResultHandlers.print())
+			.andExpect(jsonPath("$.message").value(AuctionErrorCode.INVALID_SORT_INPUT.getMessage()))
+			.andExpect(jsonPath("$.code").value(AuctionErrorCode.INVALID_SORT_INPUT.getCode()));
 	}
 }

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -89,7 +89,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.code").value(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY.getCode()));
 	}
 
-	@DisplayName("[경매를 상세정보를 조회할 수 있다.]")
+	@DisplayName("[경매 상세정보를 조회할 수 있다.]")
 	@Test
 	void getAuctionDetail() throws Exception {
 		//given

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -123,9 +123,10 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	void getRecommendAuctionsWithFilter() throws Exception {
 		//given
 		String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
-		Auction auction1 = AuctionFixture.auction(productCategory, "2024-03-11", si, gu, dong1);
-		Auction auction2 = AuctionFixture.auction(productCategory, "2024-03-07", si, gu, dong1);
-		Auction auction3 = AuctionFixture.auction(productCategory, "2024-03-08", si, gu, dong2);
+		String earlyEndDate = "2024-03-02", lateEndDate = "2024-03-10";
+		Auction auction1 = AuctionFixture.auction(productCategory, lateEndDate, si, gu, dong1);
+		Auction auction2 = AuctionFixture.auction(productCategory, earlyEndDate, si, gu, dong1);
+		Auction auction3 = AuctionFixture.auction(productCategory, lateEndDate, si, gu, dong2);
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -128,6 +128,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.productCategory")
 				.value(auction.getProduct().getProductCategory().getCategoryValue()))
 			.andExpect(jsonPath("$.initPrice").value(auction.getInitPrice()))
+			.andExpect(jsonPath("$.currentBiddingPrice").value(auction.getCurrentBiddingPrice()))
 			.andExpect(jsonPath("$.endDate").value(auction.getEndDate().toString()))
 			.andExpect(jsonPath("$.productStatus").value(auction.getProduct().getStatus().getLabel()))
 			.andExpect(jsonPath("$.purchaseTime").value(auction.getProduct().getPurchaseTime().getLabel()))

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -50,20 +50,11 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	@DisplayName("[경매를 등록할 수 있다.]")
 	@Test
 	void registerAuction() throws Exception {
-		RegisterAuctionRequest request = RegisterAuctionRequest.of(
-			"거의 새상품 버즈 팔아요",
-			DIGITAL_DEVICE,
-			10000,
-			LocalDate.parse("2022-10-18"),
-			ProductStatus.NEW.getLabel(),
-			PurchaseTime.UNDER_ONE_MONTH.getLabel(),
-			"거의 새상품이에요",
-			TradeMethod.DELIVER.getLabel(),
-			List.of("test.jpg")
-		);
+		RegisterAuctionRequest request = RegisterAuctionRequest.of("거의 새상품 버즈 팔아요", DIGITAL_DEVICE, 10000,
+			LocalDate.parse("2022-10-18"), ProductStatus.NEW.getLabel(), PurchaseTime.UNDER_ONE_MONTH.getLabel(),
+			"거의 새상품이에요", TradeMethod.DELIVER.getLabel(), List.of("test.jpg"));
 
-		mockMvc.perform(post("/api/auctions")
-				.header(AUTHORIZATION, "Bearer " + accessToken)
+		mockMvc.perform(post("/api/auctions").header(AUTHORIZATION, "Bearer " + accessToken)
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
@@ -86,30 +77,16 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	@Test
 	void registerAuctionFails() throws Exception {
 		final String NOT_EXIST_CATEGORY = "아";
-		RegisterAuctionRequest request = RegisterAuctionRequest.of(
-			"거의 새상품 버즈 팔아요",
-			NOT_EXIST_CATEGORY,
-			10000,
-			LocalDate.parse("2022-10-18"),
-			ProductStatus.NEW.getLabel(),
-			PurchaseTime.UNDER_ONE_MONTH.getLabel(),
-			"거의 새상품이에요",
-			TradeMethod.DELIVER.getLabel(),
-			List.of("test.jpg"),
-			"서울시",
-			"성북구",
-			"동선동"
-		);
+		RegisterAuctionRequest request = RegisterAuctionRequest.of("거의 새상품 버즈 팔아요", NOT_EXIST_CATEGORY, 10000,
+			LocalDate.parse("2022-10-18"), ProductStatus.NEW.getLabel(), PurchaseTime.UNDER_ONE_MONTH.getLabel(),
+			"거의 새상품이에요", TradeMethod.DELIVER.getLabel(), List.of("test.jpg"), "서울시", "성북구", "동선동");
 
-		mockMvc.perform(post("/api/auctions")
-				.header(AUTHORIZATION, "Bearer " + accessToken)
+		mockMvc.perform(post("/api/auctions").header(AUTHORIZATION, "Bearer " + accessToken)
 				.content(toJson(request))
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message")
-				.value(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY.getMessage()))
-			.andExpect(jsonPath("$.code")
-				.value(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY.getCode()));
+			.andExpect(jsonPath("$.message").value(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY.getMessage()))
+			.andExpect(jsonPath("$.code").value(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY.getCode()));
 	}
 
 	@DisplayName("[경매를 상세정보를 조회할 수 있다.]")
@@ -120,14 +97,13 @@ class AuctionApiControllerTest extends ApiTestSupport {
 		auctionRepository.save(auction);
 
 		//when, then
-		mockMvc.perform(get("/api/auctions/{auctionId}", auction.getId())
-				.contentType(APPLICATION_JSON))
+		mockMvc.perform(get("/api/auctions/{auctionId}", auction.getId()).contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.auctionId").value(auction.getId()))
 			.andExpect(jsonPath("$.sellerId").value(user.getId()))
 			.andExpect(jsonPath("$.title").value(auction.getTitle()))
-			.andExpect(jsonPath("$.productCategory")
-				.value(auction.getProduct().getProductCategory().getCategoryValue()))
+			.andExpect(
+				jsonPath("$.productCategory").value(auction.getProduct().getProductCategory().getCategoryValue()))
 			.andExpect(jsonPath("$.initPrice").value(auction.getInitPrice()))
 			.andExpect(jsonPath("$.currentBiddingPrice").value(auction.getCurrentBiddingPrice()))
 			.andExpect(jsonPath("$.endDate").value(auction.getEndDate().toString()))
@@ -153,8 +129,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when
-		mockMvc.perform(get("/api/auctions/recommend")
-				.param("sort", "마감일")
+		mockMvc.perform(get("/api/auctions/recommend").param("sort", "마감일")
 				.param("si", si)
 				.param("gu", gu)
 				.param("dong", dong1)
@@ -162,9 +137,9 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(2))
 			.andExpect(jsonPath("$.content[0].auctionId").value(auction2.getId()))
-			.andExpect(jsonPath("$.content[0].createdAt").value(auction2.getCreatedAt().toString()))
+			.andExpect(jsonPath("$.content[0].endDate").value(auction2.getEndDate().toString()))
 			.andExpect(jsonPath("$.content[1].auctionId").value(auction1.getId()))
-			.andExpect(jsonPath("$.content[1].createdAt").value(auction1.getCreatedAt().toString()))
+			.andExpect(jsonPath("$.content[1].endDate").value(auction1.getEndDate().toString()))
 			.andExpect(jsonPath("$.hasNext").value(false));
 	}
 
@@ -178,9 +153,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when
-		mockMvc.perform(get("/api/auctions/recommend")
-				.param("sort", "최근생성")
-				.contentType(APPLICATION_JSON))
+		mockMvc.perform(get("/api/auctions/recommend").param("sort", "최근생성").contentType(APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(3))
 			.andExpect(jsonPath("$.content[0].auctionId").value(auction3.getId()))
@@ -192,8 +165,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	@DisplayName("[정렬 조건이 없을 시 예외를 반환한다.]")
 	@Test
 	void getRecommendAuctions_fails() throws Exception {
-		mockMvc.perform(get("/api/auctions/recommend")
-				.contentType(APPLICATION_JSON))
+		mockMvc.perform(get("/api/auctions/recommend").contentType(APPLICATION_JSON))
 			.andDo(MockMvcResultHandlers.print())
 			.andExpect(jsonPath("$.message").value(AuctionErrorCode.EMPTY_SORT_INPUT.getMessage()))
 			.andExpect(jsonPath("$.code").value(AuctionErrorCode.EMPTY_SORT_INPUT.getCode()));
@@ -202,9 +174,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	@DisplayName("[정렬 조건이 잘못되면 예외를 반환한다.]")
 	@Test
 	void getRecommendAuctions_fails2() throws Exception {
-		mockMvc.perform(get("/api/auctions/recommend")
-				.contentType(APPLICATION_JSON)
-				.param("sort", "NAN"))
+		mockMvc.perform(get("/api/auctions/recommend").contentType(APPLICATION_JSON).param("sort", "NAN"))
 			.andDo(MockMvcResultHandlers.print())
 			.andExpect(jsonPath("$.message").value(AuctionErrorCode.INVALID_SORT_INPUT.getMessage()))
 			.andExpect(jsonPath("$.code").value(AuctionErrorCode.INVALID_SORT_INPUT.getCode()));

--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -147,7 +147,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 	void getRecommendAuctionsWithFilter() throws Exception {
 		//given
 		String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
-		Auction auction1 = AuctionFixture.auction(productCategory, "2024-03-11",si, gu, dong1);
+		Auction auction1 = AuctionFixture.auction(productCategory, "2024-03-11", si, gu, dong1);
 		Auction auction2 = AuctionFixture.auction(productCategory, "2024-03-07", si, gu, dong1);
 		Auction auction3 = AuctionFixture.auction(productCategory, "2024-03-08", si, gu, dong2);
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));

--- a/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
@@ -75,7 +75,7 @@ class SearchApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[0].initPrice").value(auction1.getInitPrice()))
 			.andExpect(jsonPath("$.content[0].bookmarkCount").value(auction1.getBookmarkCount()))
 			.andExpect(jsonPath("$.content[0].dong").value(auction1.getTradingLocation().getDong()))
-			.andExpect(jsonPath("$.content[0].createdDate").value(auction1.getCreatedAt().toLocalDate().toString()))
+			.andExpect(jsonPath("$.content[0].createdAt").exists())
 			.andExpect(jsonPath("$.content[1].title").value(auction3.getTitle()));
 	}
 

--- a/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
@@ -72,7 +72,7 @@ class SearchApiControllerTest extends ApiTestSupport {
 			.andDo(MockMvcResultHandlers.print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.content[0].title").value(auction1.getTitle()))
-			.andExpect(jsonPath("$.content[0].initPrice").value(auction1.getInitPrice()))
+			.andExpect(jsonPath("$.content[0].currentBiddingPrice").value(auction1.getCurrentBiddingPrice()))
 			.andExpect(jsonPath("$.content[0].bookmarkCount").value(auction1.getBookmarkCount()))
 			.andExpect(jsonPath("$.content[0].dong").value(auction1.getTradingLocation().getDong()))
 			.andExpect(jsonPath("$.content[0].createdAt").exists())

--- a/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/search/controller/SearchApiControllerTest.java
@@ -94,7 +94,7 @@ class SearchApiControllerTest extends ApiTestSupport {
 		mockMvc.perform(post("/api/auctions/search")
 				.content(toJson(condition))
 				.contentType(APPLICATION_JSON)
-				.param("sort", "bookmarkCount,desc"))
+				.param("sort", "북마크수"))
 			.andDo(MockMvcResultHandlers.print())
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(3))

--- a/core/src/main/generated/dev/handsup/auction/domain/QAuction.java
+++ b/core/src/main/generated/dev/handsup/auction/domain/QAuction.java
@@ -33,6 +33,8 @@ public class QAuction extends EntityPathBase<Auction> {
     //inherited
     public final DateTimePath<java.time.LocalDateTime> createdAt = _super.createdAt;
 
+    public final NumberPath<Integer> currentBiddingPrice = createNumber("currentBiddingPrice", Integer.class);
+
     public final DatePath<java.time.LocalDate> endDate = createDate("endDate", java.time.LocalDate.class);
 
     public final NumberPath<Long> id = createNumber("id", Long.class);

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -72,6 +72,9 @@ public class Auction extends TimeBaseEntity {
 	@Column(name = "init_price", nullable = false)
 	private int initPrice;
 
+	@Column(name = "current_bidding_price", nullable = false)
+	private int currentBiddingPrice;
+
 	@Column(name = "end_date", nullable = false)
 	private LocalDate endDate;
 
@@ -101,6 +104,7 @@ public class Auction extends TimeBaseEntity {
 		this.title = title;
 		this.product = product;
 		this.initPrice = initPrice;
+		this.currentBiddingPrice = initPrice;
 		this.endDate = endDate;
 		this.tradingLocation = tradingLocation;
 		this.tradeMethod = tradeMethod;
@@ -115,6 +119,7 @@ public class Auction extends TimeBaseEntity {
 		this.title = title;
 		this.product = product;
 		this.initPrice = initPrice;
+		this.currentBiddingPrice = initPrice;
 		this.endDate = endDate;
 		this.tradingLocation = tradingLocation;
 		this.tradeMethod = tradeMethod;
@@ -160,5 +165,9 @@ public class Auction extends TimeBaseEntity {
 
 	public void decreaseBookmarkCount() {
 		bookmarkCount--;
+	}
+
+	public void updateCurrentBiddingPrice(int currentBiddingPrice) {
+		this.currentBiddingPrice = currentBiddingPrice;
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -78,7 +78,7 @@ public class AuctionMapper {
 		);
 	}
 
-	public static RecommendAuctionResponse toRecommendAuctionResponse(Auction auction){
+	public static RecommendAuctionResponse toRecommendAuctionResponse(Auction auction) {
 		return RecommendAuctionResponse.of(
 			auction.getId(),
 			auction.getTitle(),

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -49,6 +49,7 @@ public class AuctionMapper {
 			auction.getTitle(),
 			auction.getProduct().getProductCategory().getCategoryValue(),
 			auction.getInitPrice(),
+			auction.getCurrentBiddingPrice(),
 			auction.getEndDate().toString(),
 			auction.getProduct().getStatus().getLabel(),
 			auction.getProduct().getPurchaseTime().getLabel(),
@@ -68,7 +69,7 @@ public class AuctionMapper {
 		return AuctionSimpleResponse.of(
 			auction.getId(),
 			auction.getTitle(),
-			auction.getInitPrice(),
+			auction.getCurrentBiddingPrice(),
 			auction.getProduct().getImages().get(0).getImageUrl(),
 			auction.getBookmarkCount(),
 			auction.getTradingLocation().getDong(),

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -80,6 +80,7 @@ public class AuctionMapper {
 
 	public static RecommendAuctionResponse toRecommendAuctionResponse(Auction auction){
 		return RecommendAuctionResponse.of(
+			auction.getId(),
 			auction.getTitle(),
 			auction.getTradingLocation().getDong(),
 			auction.getCurrentBiddingPrice(),

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -87,7 +87,8 @@ public class AuctionMapper {
 			auction.getProduct().getImages().get(0).getImageUrl(),
 			auction.getBookmarkCount(),
 			auction.getBiddingCount(),
-			auction.getCreatedAt().toString()
+			auction.getCreatedAt().toString(),
+			auction.getEndDate().toString()
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -72,7 +72,7 @@ public class AuctionMapper {
 			auction.getProduct().getImages().get(0).getImageUrl(),
 			auction.getBookmarkCount(),
 			auction.getTradingLocation().getDong(),
-			auction.getCreatedAt().toLocalDate().toString()
+			auction.getCreatedAt().toString()
 		);
 
 	}

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -13,6 +13,7 @@ import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.RegisterAuctionRequest;
 import dev.handsup.auction.dto.response.AuctionDetailResponse;
 import dev.handsup.auction.dto.response.AuctionSimpleResponse;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.user.domain.User;
 import lombok.NoArgsConstructor;
@@ -75,7 +76,18 @@ public class AuctionMapper {
 			auction.getTradingLocation().getDong(),
 			auction.getCreatedAt().toString()
 		);
+	}
 
+	public static RecommendAuctionResponse toRecommendAuctionResponse(Auction auction){
+		return RecommendAuctionResponse.of(
+			auction.getTitle(),
+			auction.getTradingLocation().getDong(),
+			auction.getCurrentBiddingPrice(),
+			auction.getProduct().getImages().get(0).getImageUrl(),
+			auction.getBookmarkCount(),
+			auction.getBiddingCount(),
+			auction.getCreatedAt().toString()
+		);
 	}
 
 	public static <T> PageResponse<T> toPageResponse(Slice<T> page) {

--- a/core/src/main/java/dev/handsup/auction/dto/response/AuctionDetailResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/AuctionDetailResponse.java
@@ -9,6 +9,7 @@ public record AuctionDetailResponse(
 	String title,
 	String productCategory,
 	int initPrice,
+	int currentBiddingPrice,
 	String endDate,
 	String productStatus,
 	String purchaseTime,
@@ -30,6 +31,7 @@ public record AuctionDetailResponse(
 		String title,
 		String productCategory,
 		int initPrice,
+		int currentBiddingPrice,
 		String endDate,
 		String productStatus,
 		String purchaseTime,
@@ -43,7 +45,7 @@ public record AuctionDetailResponse(
 		String createdAt
 	) {
 		return new AuctionDetailResponse(
-			auctionId, sellerId, title, productCategory, initPrice, endDate, productStatus, purchaseTime, description,
+			auctionId, sellerId, title, productCategory, initPrice, currentBiddingPrice, endDate, productStatus, purchaseTime, description,
 			tradeMethod, imageUrls, si, gu, dong, bookmarkCount, createdAt);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/response/AuctionDetailResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/AuctionDetailResponse.java
@@ -45,7 +45,8 @@ public record AuctionDetailResponse(
 		String createdAt
 	) {
 		return new AuctionDetailResponse(
-			auctionId, sellerId, title, productCategory, initPrice, currentBiddingPrice, endDate, productStatus, purchaseTime, description,
+			auctionId, sellerId, title, productCategory, initPrice, currentBiddingPrice, endDate, productStatus,
+			purchaseTime, description,
 			tradeMethod, imageUrls, si, gu, dong, bookmarkCount, createdAt);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/response/AuctionSimpleResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/AuctionSimpleResponse.java
@@ -7,7 +7,7 @@ public record AuctionSimpleResponse(
 	String imageUrl,
 	int bookmarkCount,
 	String dong,
-	String createdDate
+	String createdAt
 
 ) {
 	public static AuctionSimpleResponse of(
@@ -17,7 +17,7 @@ public record AuctionSimpleResponse(
 		String imageUrl,
 		int bookmarkCount,
 		String dong,
-		String createDate
+		String createdAt
 	) {
 		return new AuctionSimpleResponse(
 			auctionId,
@@ -26,7 +26,7 @@ public record AuctionSimpleResponse(
 			imageUrl,
 			bookmarkCount,
 			dong,
-			createDate
+			createdAt
 		);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/response/AuctionSimpleResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/AuctionSimpleResponse.java
@@ -3,7 +3,7 @@ package dev.handsup.auction.dto.response;
 public record AuctionSimpleResponse(
 	Long auctionId,
 	String title,
-	int initPrice,
+	int currentBiddingPrice,
 	String imageUrl,
 	int bookmarkCount,
 	String dong,
@@ -13,7 +13,7 @@ public record AuctionSimpleResponse(
 	public static AuctionSimpleResponse of(
 		Long auctionId,
 		String title,
-		int initPrice,
+		int currentBiddingPrice,
 		String imageUrl,
 		int bookmarkCount,
 		String dong,
@@ -22,7 +22,7 @@ public record AuctionSimpleResponse(
 		return new AuctionSimpleResponse(
 			auctionId,
 			title,
-			initPrice,
+			currentBiddingPrice,
 			imageUrl,
 			bookmarkCount,
 			dong,

--- a/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
@@ -1,0 +1,24 @@
+package dev.handsup.auction.dto.response;
+
+public record RecommendAuctionResponse(
+	String title,
+	String dong,
+	int currentBiddingPrice,
+	String imgUrl,
+	int bookmarkCount,
+	int biddingCount,
+	String createdAt
+) {
+	public static RecommendAuctionResponse of(
+		String title,
+		String dong,
+		int currentBiddingPrice,
+		String imgUrl,
+		int bookmarkCount,
+		int biddingCount,
+		String createdAt
+	) {
+		return new RecommendAuctionResponse(
+			title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt);
+	}
+}

--- a/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
@@ -1,6 +1,7 @@
 package dev.handsup.auction.dto.response;
 
 public record RecommendAuctionResponse(
+	Long auctionId,
 	String title,
 	String dong,
 	int currentBiddingPrice,
@@ -10,6 +11,7 @@ public record RecommendAuctionResponse(
 	String createdAt
 ) {
 	public static RecommendAuctionResponse of(
+		Long auctionId,
 		String title,
 		String dong,
 		int currentBiddingPrice,
@@ -19,6 +21,6 @@ public record RecommendAuctionResponse(
 		String createdAt
 	) {
 		return new RecommendAuctionResponse(
-			title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt);
+			 auctionId, title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
@@ -23,6 +23,6 @@ public record RecommendAuctionResponse(
 		String endDate
 	) {
 		return new RecommendAuctionResponse(
-			 auctionId, title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt, endDate);
+			auctionId, title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt, endDate);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
+++ b/core/src/main/java/dev/handsup/auction/dto/response/RecommendAuctionResponse.java
@@ -8,7 +8,8 @@ public record RecommendAuctionResponse(
 	String imgUrl,
 	int bookmarkCount,
 	int biddingCount,
-	String createdAt
+	String createdAt,
+	String endDate
 ) {
 	public static RecommendAuctionResponse of(
 		Long auctionId,
@@ -18,9 +19,10 @@ public record RecommendAuctionResponse(
 		String imgUrl,
 		int bookmarkCount,
 		int biddingCount,
-		String createdAt
+		String createdAt,
+		String endDate
 	) {
 		return new RecommendAuctionResponse(
-			 auctionId, title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt);
+			 auctionId, title, dong, currentBiddingPrice, imgUrl, bookmarkCount, biddingCount, createdAt, endDate);
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
+++ b/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
@@ -12,8 +12,9 @@ public enum AuctionErrorCode implements ErrorCode {
 	NOT_FOUND_PRODUCT_STATUS("상품 상태를 올바르게 입력해주세요.", "AU_001"),
 	NOT_FOUND_PURCHASE_TIME("구매 시기를 올바르게 입력해주세요.", "AU_002"),
 	NOT_FOUND_TADE_METHOD("거래 방법을 올바르게 입력해주세요.", "AU_003"),
-	NOT_FOUND_PRODUCT_CATEGORY("상품 카테고리를 올바르게 입력해주세요.", "AU_004");
-
+	NOT_FOUND_PRODUCT_CATEGORY("상품 카테고리를 올바르게 입력해주세요.", "AU_004"),
+	INVALID_SORT_INPUT("정렬 기준을 올바르게 입력해주세요.", "AU_005"),
+	EMPTY_SORT_INPUT("정렬 기준을 입력해주세요.", "AU_006");
 	private final String message;
 	private final String code;
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
@@ -8,5 +8,6 @@ import dev.handsup.auction.dto.request.AuctionSearchCondition;
 
 public interface AuctionQueryRepository {
 	Slice<Auction> searchAuctions(AuctionSearchCondition auctionSearchCondition, Pageable pageable);
+
 	Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
@@ -8,4 +8,5 @@ import dev.handsup.auction.dto.request.AuctionSearchCondition;
 
 public interface AuctionQueryRepository {
 	Slice<Auction> searchAuctions(AuctionSearchCondition auctionSearchCondition, Pageable pageable);
+	Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -118,11 +118,11 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 	}
 
 	private BooleanExpression guEq(String gu) {
-		return hasText(gu) ? auction.tradingLocation.si.eq(gu) : null;
+		return hasText(gu) ? auction.tradingLocation.gu.eq(gu) : null;
 	}
 
 	private BooleanExpression dongEq(String dong) {
-		return hasText(dong) ? auction.tradingLocation.si.eq(dong) : null;
+		return hasText(dong) ? auction.tradingLocation.dong.eq(dong) : null;
 	}
 
 	private BooleanExpression initPriceBetween(Integer minPrice, Integer maxPrice) {

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -81,7 +81,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 			.findFirst()
 			.map(order -> switch (order.getProperty()) {
 				case "북마크수" -> auction.bookmarkCount.desc();
-				case "마감일" -> auction.endDate.desc();
+				case "마감일" -> auction.endDate.asc();
 				case "입찰수" -> auction.biddingCount.desc();
 				default -> auction.createdAt.desc();
 			})
@@ -93,7 +93,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 			.findFirst()
 			.map(order -> switch (order.getProperty()) {
 				case "북마크수" -> auction.bookmarkCount.desc();
-				case "마감일" -> auction.endDate.desc();
+				case "마감일" -> auction.endDate.asc();
 				case "입찰수" -> auction.biddingCount.desc();
 				case "최근생성" -> auction.createdAt.desc();
 				default -> throw new ValidationException(AuctionErrorCode.INVALID_SORT_INPUT); //기본값 비허용

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -98,7 +98,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 				case "최근생성" -> auction.createdAt.desc();
 				default -> throw new ValidationException(AuctionErrorCode.INVALID_SORT_INPUT); //기본값 비허용
 			})
-			.orElseThrow(()-> new ValidationException(AuctionErrorCode.EMPTY_SORT_INPUT)); //null 비허용
+			.orElseThrow(() -> new ValidationException(AuctionErrorCode.EMPTY_SORT_INPUT)); //null 비허용
 	}
 
 	private BooleanExpression keywordContains(String keyword) {

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -12,7 +12,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -23,6 +22,8 @@ import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.domain.auction_field.TradeMethod;
 import dev.handsup.auction.domain.product.ProductStatus;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
+import dev.handsup.auction.exception.AuctionErrorCode;
+import dev.handsup.common.exception.ValidationException;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -48,7 +49,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 				isNewProductEq(condition.isNewProduct()),
 				isProgressEq(condition.isProgress())
 			)
-			.orderBy(auctionSort(pageable))
+			.orderBy(searchAuctionSort(pageable))
 			.limit(pageable.getPageSize() + 1L)
 			.offset(pageable.getOffset())
 			.fetch();
@@ -56,19 +57,48 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 		return new SliceImpl<>(content, pageable, hasNext);
 	}
 
-	private OrderSpecifier<?> auctionSort(Pageable pageable) {
+	@Override
+	public Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong, Pageable pageable) {
+		List<Auction> content = queryFactory.select(QAuction.auction)
+			.from(auction)
+			.join(auction.product, product).fetchJoin()
+			.where(
+				auction.status.eq(AuctionStatus.PROGRESS),
+				siEq(si),
+				guEq(gu),
+				dongEq(dong)
+			)
+			.orderBy(recommendAuctionSort(pageable))
+			.limit(pageable.getPageSize() + 1L)
+			.offset(pageable.getOffset())
+			.fetch();
+		boolean hasNext = hasNext(pageable.getPageSize(), content);
+		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	private OrderSpecifier<?> searchAuctionSort(Pageable pageable) {
 		return pageable.getSort().stream()
 			.findFirst()
-			.map(order -> {
-				Order direction = order.getDirection().isAscending() ? Order.ASC : Order.DESC;
-				return switch (order.getProperty()) {
-					case "bookmarkCount" -> new OrderSpecifier<>(direction, auction.bookmarkCount);
-					case "endDate" -> new OrderSpecifier<>(direction, auction.endDate);
-					case "initPrice" -> new OrderSpecifier<>(direction, auction.initPrice);
-					default -> auction.createdAt.desc();
-				};
+			.map(order -> switch (order.getProperty()) {
+				case "북마크수" -> auction.bookmarkCount.desc();
+				case "마감일" -> auction.endDate.desc();
+				case "입찰수" -> auction.biddingCount.desc();
+				default -> auction.createdAt.desc();
 			})
-			.orElse(auction.createdAt.desc());
+			.orElse(auction.createdAt.desc()); // 기본값 최신순
+	}
+
+	private OrderSpecifier<?> recommendAuctionSort(Pageable pageable) {
+		return pageable.getSort().stream()
+			.findFirst()
+			.map(order -> switch (order.getProperty()) {
+				case "북마크수" -> auction.bookmarkCount.desc();
+				case "마감일" -> auction.endDate.desc();
+				case "입찰수" -> auction.biddingCount.desc();
+				case "최근생성" -> auction.createdAt.desc();
+				default -> throw new ValidationException(AuctionErrorCode.INVALID_SORT_INPUT); //기본값 비허용
+			})
+			.orElseThrow(()-> new ValidationException(AuctionErrorCode.EMPTY_SORT_INPUT)); //null 비허용
 	}
 
 	private BooleanExpression keywordContains(String keyword) {

--- a/core/src/main/java/dev/handsup/auction/service/AuctionService.java
+++ b/core/src/main/java/dev/handsup/auction/service/AuctionService.java
@@ -48,7 +48,8 @@ public class AuctionService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<RecommendAuctionResponse> getRecommendAuctions(String si, String gu, String dong, Pageable pageable) {
+	public PageResponse<RecommendAuctionResponse> getRecommendAuctions(String si, String gu, String dong,
+		Pageable pageable) {
 		Slice<RecommendAuctionResponse> auctionResponsePage = auctionQueryRepository
 			.sortAuctionByCriteria(si, gu, dong, pageable)
 			.map(AuctionMapper::toRecommendAuctionResponse);

--- a/core/src/main/java/dev/handsup/auction/service/AuctionService.java
+++ b/core/src/main/java/dev/handsup/auction/service/AuctionService.java
@@ -2,6 +2,8 @@ package dev.handsup.auction.service;
 
 import static dev.handsup.auction.exception.AuctionErrorCode.*;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -10,9 +12,12 @@ import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.mapper.AuctionMapper;
 import dev.handsup.auction.dto.request.RegisterAuctionRequest;
 import dev.handsup.auction.dto.response.AuctionDetailResponse;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.exception.AuctionErrorCode;
+import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.common.dto.PageResponse;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.user.domain.User;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +28,7 @@ public class AuctionService {
 
 	private final AuctionRepository auctionRepository;
 	private final ProductCategoryRepository productCategoryRepository;
+	private final AuctionQueryRepository auctionQueryRepository;
 
 	public Auction getAuction(Long auctionId) {
 		return auctionRepository.findById(auctionId)
@@ -39,6 +45,14 @@ public class AuctionService {
 	public AuctionDetailResponse getAuctionDetail(Long auctionId) {
 		Auction auction = getAuction(auctionId);
 		return AuctionMapper.toAuctionDetailResponse(auction);
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse<RecommendAuctionResponse> getRecommendAuctions(String si, String gu, String dong, Pageable pageable) {
+		Slice<RecommendAuctionResponse> auctionResponsePage = auctionQueryRepository
+			.sortAuctionByCriteria(si, gu, dong, pageable)
+			.map(AuctionMapper::toRecommendAuctionResponse);
+		return AuctionMapper.toPageResponse(auctionResponsePage);
 	}
 
 	private ProductCategory getProductCategoryEntity(RegisterAuctionRequest request) {

--- a/core/src/main/java/dev/handsup/bidding/dto/request/RegisterBiddingRequest.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/request/RegisterBiddingRequest.java
@@ -9,7 +9,7 @@ import lombok.Builder;
 @Builder(access = PRIVATE)
 public record RegisterBiddingRequest(
 
-	@NotNull(message = "biddingPrice 값이 공백입니다.")
+	@NotNull(message = "currentBiddingPrice 값이 공백입니다.")
 	@Max(value = 1_000_000_000, message = "최대 입찰가는 10억입니다.")
 	int biddingPrice
 ) {

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -49,6 +49,7 @@ public class BiddingService {
 		Bidding savedBidding = biddingRepository.save(
 			BiddingMapper.toBidding(request, auction, bidder)
 		);
+		auction.updateCurrentBiddingPrice(savedBidding.getBiddingPrice());
 		return BiddingMapper.toBiddingResponse(savedBidding);
 	}
 

--- a/core/src/main/java/dev/handsup/search/service/SearchService.java
+++ b/core/src/main/java/dev/handsup/search/service/SearchService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.handsup.auction.dto.mapper.AuctionMapper;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
 import dev.handsup.auction.dto.response.AuctionSimpleResponse;
-import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import dev.handsup.auction.repository.search.RedisSearchRepository;
 import dev.handsup.common.dto.PageResponse;
@@ -35,13 +34,5 @@ public class SearchService {
 	@Transactional(readOnly = true)
 	public PopularKeywordsResponse getPopularKeywords() {
 		return SearchMapper.toPopularKeywordsResponse(redisSearchRepository.getPopularKeywords(10));
-	}
-
-	@Transactional(readOnly = true)
-	public PageResponse<RecommendAuctionResponse> getRecommendAuctions(String si, String gu, String dong, Pageable pageable) {
-		Slice<RecommendAuctionResponse> auctionResponsePage = auctionQueryRepository
-			.sortAuctionByCriteria(si, gu, dong, pageable)
-			.map(AuctionMapper::toRecommendAuctionResponse);
-		return AuctionMapper.toPageResponse(auctionResponsePage);
 	}
 }

--- a/core/src/main/java/dev/handsup/search/service/SearchService.java
+++ b/core/src/main/java/dev/handsup/search/service/SearchService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.handsup.auction.dto.mapper.AuctionMapper;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
 import dev.handsup.auction.dto.response.AuctionSimpleResponse;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import dev.handsup.auction.repository.search.RedisSearchRepository;
 import dev.handsup.common.dto.PageResponse;
@@ -34,5 +35,13 @@ public class SearchService {
 	@Transactional(readOnly = true)
 	public PopularKeywordsResponse getPopularKeywords() {
 		return SearchMapper.toPopularKeywordsResponse(redisSearchRepository.getPopularKeywords(10));
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse<RecommendAuctionResponse> getRecommendAuctions(String si, String gu, String dong, Pageable pageable) {
+		Slice<RecommendAuctionResponse> auctionResponsePage = auctionQueryRepository
+			.sortAuctionByCriteria(si, gu, dong, pageable)
+			.map(AuctionMapper::toRecommendAuctionResponse);
+		return AuctionMapper.toPageResponse(auctionResponsePage);
 	}
 }

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImplTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImplTest.java
@@ -222,7 +222,7 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
 	@DisplayName("[입찰수 순으로 경매를 조회할 수 있다.]")
 	@Test
 	void sortAuctionByCriteria() {
-	    //given
+		//given
 		Auction auction1 = AuctionFixture.auction(category1);
 		ReflectionTestUtils.setField(auction1, "biddingCount", 4);
 		Auction auction2 = AuctionFixture.auction(category1);
@@ -230,7 +230,7 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
 
 		auctionRepository.saveAll(List.of(auction1, auction2));
 		PageRequest pageRequest = PageRequest.of(0, 10, Sort.by("입찰수"));
-	    //when
+		//when
 		List<Auction> auctions = auctionQueryRepository.sortAuctionByCriteria(null, null, null, pageRequest)
 			.getContent();
 		//then
@@ -241,7 +241,7 @@ class AuctionQueryRepositoryImplTest extends DataJpaTestSupport {
 	@Test
 	void sortAuctionByCriteria2() {
 		//given
-		String si = "서울시", gu="서초구", dong1 = "방배동", dong2 = "반포동";
+		String si = "서울시", gu = "서초구", dong1 = "방배동", dong2 = "반포동";
 		Auction auction1 = AuctionFixture.auction(category1, si, gu, dong1);
 		ReflectionTestUtils.setField(auction1, "bookmarkCount", 4);
 		Auction auction2 = AuctionFixture.auction(category2, si, gu, dong1);

--- a/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
@@ -42,6 +42,7 @@ class AuctionServiceTest {
 
 	@Mock
 	private AuctionRepository auctionRepository;
+
 	@Mock
 	private ProductCategoryRepository productCategoryRepository;
 
@@ -112,5 +113,4 @@ class AuctionServiceTest {
 			.isInstanceOf(NotFoundException.class)
 			.hasMessageContaining(AuctionErrorCode.NOT_FOUND_AUCTION.getMessage());
 	}
-
 }

--- a/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
@@ -15,6 +15,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
@@ -24,9 +27,12 @@ import dev.handsup.auction.domain.product.ProductStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.RegisterAuctionRequest;
 import dev.handsup.auction.dto.response.AuctionDetailResponse;
+import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.exception.AuctionErrorCode;
+import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.common.dto.PageResponse;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.ProductFixture;
@@ -42,6 +48,9 @@ class AuctionServiceTest {
 
 	@Mock
 	private AuctionRepository auctionRepository;
+
+	@Mock
+	private AuctionQueryRepository auctionQueryRepository;
 
 	@Mock
 	private ProductCategoryRepository productCategoryRepository;
@@ -112,5 +121,20 @@ class AuctionServiceTest {
 		assertThatThrownBy(() -> auctionService.getAuctionEntity(auctionId))
 			.isInstanceOf(NotFoundException.class)
 			.hasMessageContaining(AuctionErrorCode.NOT_FOUND_AUCTION.getMessage());
+	}
+
+	@DisplayName("정렬 조건에 따라 추천 경매를 조회할 수 있다.")
+	@Test
+	void getRecommendAuctions() {
+		//given
+		PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("북마크수"));
+		ReflectionTestUtils.setField(auction, "createdAt",LocalDateTime.now());
+		given(auctionQueryRepository.sortAuctionByCriteria(null, null, null, pageRequest))
+			.willReturn(new SliceImpl<>(List.of(auction), pageRequest, false));
+		//when
+		PageResponse<RecommendAuctionResponse> response
+			= auctionService.getRecommendAuctions(null, null, null, pageRequest);
+		//then
+		assertThat(response.content().get(0)).isNotNull();
 	}
 }

--- a/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
@@ -128,7 +128,7 @@ class AuctionServiceTest {
 	void getRecommendAuctions() {
 		//given
 		PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("북마크수"));
-		ReflectionTestUtils.setField(auction, "createdAt",LocalDateTime.now());
+		ReflectionTestUtils.setField(auction, "createdAt", LocalDateTime.now());
 		given(auctionQueryRepository.sortAuctionByCriteria(null, null, null, pageRequest))
 			.willReturn(new SliceImpl<>(List.of(auction), pageRequest, false));
 		//when

--- a/core/src/test/java/dev/handsup/search/service/SearchServiceTest.java
+++ b/core/src/test/java/dev/handsup/search/service/SearchServiceTest.java
@@ -15,14 +15,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.dto.request.AuctionSearchCondition;
 import dev.handsup.auction.dto.response.AuctionSimpleResponse;
-import dev.handsup.auction.dto.response.RecommendAuctionResponse;
 import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import dev.handsup.auction.repository.search.RedisSearchRepository;
 import dev.handsup.common.dto.PageResponse;
@@ -34,7 +31,6 @@ import dev.handsup.search.dto.PopularKeywordsResponse;
 @ExtendWith(MockitoExtension.class)
 class SearchServiceTest {
 	private final Auction auction = AuctionFixture.auction();
-	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final int PAGE_NUMBER = 0;
 	private final int PAGE_SIZE = 5;
 
@@ -51,7 +47,6 @@ class SearchServiceTest {
 	@Test
 	void searchAuctions() {
 		//given
-		Auction auction = AuctionFixture.auction(ProductCategory.of(DIGITAL_DEVICE));
 		ReflectionTestUtils.setField(auction, "createdAt", LocalDateTime.now());
 
 		PageRequest pageRequest = PageRequest.of(PAGE_NUMBER, PAGE_SIZE);
@@ -99,20 +94,5 @@ class SearchServiceTest {
 			() -> assertThat(response.keywords().get(1).count())
 				.isEqualTo(popularKeywordResponse2.count())
 		);
-	}
-
-	@DisplayName("정렬 조건에 따라 추천 경매를 조회할 수 있다.")
-	@Test
-	void getRecommendAuctions() {
-		//given
-		PageRequest pageRequest = PageRequest.of(0, 5, Sort.by("북마크수"));
-		ReflectionTestUtils.setField(auction, "createdAt",LocalDateTime.now());
-		given(auctionQueryRepository.sortAuctionByCriteria(null, null, null, pageRequest))
-			.willReturn(new SliceImpl<>(List.of(auction), pageRequest, false));
-		//when
-		PageResponse<RecommendAuctionResponse> response
-			= searchService.getRecommendAuctions(null, null, null, pageRequest);
-		//then
-		assertThat(response.content().get(0)).isNotNull();
 	}
 }

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
 public class AuctionFixture {
 
 	static final String TITLE = "거의 새상품 버즈 팔아요";
-	static final String DATE = "2022-10-18";
+	static final String END_DATE = "2022-10-18";
 	static final String DIGITAL_DEVICE = "디지털 기기";
 	static final String DESCRIPTION = "거의 새상품이에요";
 	static final String SI = "서울시";
@@ -31,7 +31,7 @@ public class AuctionFixture {
 			TITLE,
 			ProductCategory.of(DIGITAL_DEVICE),
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -49,7 +49,7 @@ public class AuctionFixture {
 			TITLE,
 			productCategory,
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -67,7 +67,7 @@ public class AuctionFixture {
 			TITLE,
 			productCategory,
 			initPrice,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -85,7 +85,7 @@ public class AuctionFixture {
 			TITLE,
 			productCategory,
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			productStatus,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -103,7 +103,7 @@ public class AuctionFixture {
 			TITLE,
 			productCategory,
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -121,7 +121,7 @@ public class AuctionFixture {
 			title,
 			productCategory,
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -139,7 +139,7 @@ public class AuctionFixture {
 			title,
 			productCategory,
 			initPrice,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
@@ -157,7 +157,25 @@ public class AuctionFixture {
 			TITLE,
 			productCategory,
 			10000,
-			LocalDate.parse(DATE),
+			LocalDate.parse(END_DATE),
+			ProductStatus.NEW,
+			PurchaseTime.UNDER_ONE_MONTH,
+			DESCRIPTION,
+			TradeMethod.DIRECT,
+			List.of("image.jpg"),
+			si,
+			gu,
+			dong
+		);
+	}
+
+	public static Auction auction(ProductCategory productCategory, String endDate, String si, String gu, String dong) {
+		return Auction.of(
+			UserFixture.user(),
+			TITLE,
+			productCategory,
+			10000,
+			LocalDate.parse(endDate),
 			ProductStatus.NEW,
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -150,4 +150,22 @@ public class AuctionFixture {
 			DONG
 		);
 	}
+
+	public static Auction auction(ProductCategory productCategory, String si, String gu, String dong) {
+		return Auction.of(
+			UserFixture.user(),
+			TITLE,
+			productCategory,
+			10000,
+			LocalDate.parse(DATE),
+			ProductStatus.NEW,
+			PurchaseTime.UNDER_ONE_MONTH,
+			DESCRIPTION,
+			TradeMethod.DIRECT,
+			List.of("image.jpg"),
+			si,
+			gu,
+			dong
+		);
+	}
 }


### PR DESCRIPTION
close #49 
### 📑 작업 상세 내용
- 경매 추천 API 추가
  - 정렬 기준에 따라 조회 (입찰수, 마감일, 북마크수, 최근생성)
  - 지역에 따른 필터링
  - 정렬 기준은 필수고, 지역 필터링은 선택
  
- 경매 엔티티에 `현재 입찰 가격` 필드 추가
  - 입찰 생성 시 `현재 입찰 가격` 갱신하는 로직 추가
- 검색 API 수정
  - 시, 구, 동 필터 오류 수정
  - 정렬 기준 좁힘(입찰수,마감일,북마크수,최근생성으로 정렬 가능하게)
 

### 💫 작업 요약

- 경매 추천 API 추가
- 검색 API 오류 및 정렬 기준 수정

### 🔍 중점적으로 리뷰 할 부분

- auctionRepositoryQueryImpl
- auctionRepositoryQueryImplTest