### PR TITLE
[feat] : 경매 상태 변경 스케줄러 구현

### DIFF
--- a/api/src/main/java/dev/handsup/common/config/CorsConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/CorsConfig.java
@@ -1,0 +1,17 @@
+package dev.handsup.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@EnableWebMvc
+public class CorsConfig implements WebMvcConfigurer {
+	@Override
+	public void addCorsMappings(CorsRegistry registry) {
+		registry.addMapping("/**")
+			.allowedOrigins("http://localhost:3000")
+			.allowedMethods("GET", "POST", "PUT", "DELETE");
+	}
+}

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -84,7 +84,7 @@ public class Auction extends TimeBaseEntity {
 
 	@Column(name = "auction_status", nullable = false)
 	@Enumerated(STRING)
-	private AuctionStatus status = PROGRESS;
+	private AuctionStatus status = BIDDING;
 
 	@Column(name = "bidding_count", nullable = false)
 	private int biddingCount = 0;

--- a/core/src/main/java/dev/handsup/auction/domain/auction_field/AuctionStatus.java
+++ b/core/src/main/java/dev/handsup/auction/domain/auction_field/AuctionStatus.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuctionStatus {
 
-	PROGRESS("입찰중"),
+	BIDDING("입찰중"),
 	TRADING("거래중"),
 	COMPLETED("종료"),
 	CANCELED("취소");

--- a/core/src/main/java/dev/handsup/auction/domain/auction_field/AuctionStatus.java
+++ b/core/src/main/java/dev/handsup/auction/domain/auction_field/AuctionStatus.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum AuctionStatus {
 
-	PROGRESS("경매중"),
+	PROGRESS("입찰중"),
 	TRADING("거래중"),
-	COMPLETED("완료"),
+	COMPLETED("종료"),
 	CANCELED("취소");
 
 	private final String label;

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -112,7 +112,7 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 
 	private BooleanExpression isProgressEq(Boolean isProgress) {
 		if (Boolean.TRUE.equals(isProgress)) {
-			return auction.status.eq(AuctionStatus.PROGRESS);
+			return auction.status.eq(AuctionStatus.BIDDING);
 		}
 		return null;
 	}

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
@@ -1,16 +1,31 @@
 package dev.handsup.auction.repository.auction;
 
+import java.time.LocalDate;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.user.domain.User;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@Query("select distinct b.auction from Bookmark b " +
 		"where b.user = :user")
 	Slice<Auction> findBookmarkAuction(@Param("user") User user, Pageable pageable);
+
+	@Transactional
+	@Modifying(clearAutomatically = true)
+	@Query("update Auction a set a.status = :newStatus "
+		+ "where a.status = :currentStatus and a.endDate < :todayDate")
+	void updateAuctionStatus(
+		@Param("currentStatus") AuctionStatus currentStatus,
+		@Param("newStatus")AuctionStatus newStatus,
+		@Param("todayDate") LocalDate todayDate
+	);
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
@@ -25,7 +25,7 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 		+ "where a.status = :currentStatus and a.endDate < :todayDate")
 	void updateAuctionStatus(
 		@Param("currentStatus") AuctionStatus currentStatus,
-		@Param("newStatus")AuctionStatus newStatus,
+		@Param("newStatus") AuctionStatus newStatus,
 		@Param("todayDate") LocalDate todayDate
 	);
 }

--- a/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
+++ b/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
@@ -1,0 +1,25 @@
+package dev.handsup.auction.scheduler;
+
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
+import dev.handsup.auction.repository.auction.AuctionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class AuctionScheduler {
+	private final AuctionRepository auctionRepository;
+	private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
+
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void updateAuctionStatus() {
+		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING, LocalDate.now());
+	}
+}

--- a/core/src/main/java/dev/handsup/common/config/SchedulerConfig.java
+++ b/core/src/main/java/dev/handsup/common/config/SchedulerConfig.java
@@ -1,0 +1,9 @@
+package dev.handsup.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulerConfig {
+}

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.auction_field.AuctionStatus;
@@ -80,13 +79,12 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 
 	}
 
-	@Transactional
-	@DisplayName("[특정 날짜의 이전의 특정 경매 상태를 새로운 경매 상태로 변경한다.")
+	@DisplayName("[마감 일자가 지난 경매의 상태를 새로운 경매 상태로 변경한다.")
 	@Test
 	void updateAuctionStatus() {
 		//given
 		LocalDate today = LocalDate.now();
-		Auction auction1 = AuctionFixture.auction(category, today.minusDays(1));
+		Auction auction1 = AuctionFixture.auction(category, today.minusDays(1)); // 마감 일자(endDate)
 		Auction auction2 = AuctionFixture.auction(category, today);
 		Auction auction3 = AuctionFixture.auction(category, today.plusDays(1));
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -84,7 +84,7 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 	@DisplayName("[특정 날짜의 이전의 특정 경매 상태를 새로운 경매 상태로 변경한다.")
 	@Test
 	void updateAuctionStatus() {
-	    //given
+		//given
 		LocalDate today = LocalDate.now();
 		Auction auction1 = AuctionFixture.auction(category, today.minusDays(1));
 		Auction auction2 = AuctionFixture.auction(category, today);
@@ -92,12 +92,13 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when
-		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING, today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
+		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING,
+			today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
 		Auction savedAuction1 = auctionRepository.findById(auction1.getId()).orElseThrow();
 		Auction savedAuction2 = auctionRepository.findById(auction2.getId()).orElseThrow();
 		Auction savedAuction3 = auctionRepository.findById(auction3.getId()).orElseThrow();
 
-	    //then
+		//then
 		assertAll(
 			() -> assertThat(savedAuction1.getStatus()).isEqualTo(AuctionStatus.TRADING),
 			() -> assertThat(savedAuction2.getStatus()).isEqualTo(AuctionStatus.BIDDING),

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -92,7 +92,7 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when
-		auctionRepository.updateAuctionStatus(AuctionStatus.PROGRESS, AuctionStatus.TRADING, today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
+		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING, today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
 		Auction savedAuction1 = auctionRepository.findById(auction1.getId()).orElseThrow();
 		Auction savedAuction2 = auctionRepository.findById(auction2.getId()).orElseThrow();
 		Auction savedAuction3 = auctionRepository.findById(auction3.getId()).orElseThrow();
@@ -100,8 +100,8 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 	    //then
 		assertAll(
 			() -> assertThat(savedAuction1.getStatus()).isEqualTo(AuctionStatus.TRADING),
-			() -> assertThat(savedAuction2.getStatus()).isEqualTo(AuctionStatus.PROGRESS),
-			() -> assertThat(savedAuction3.getStatus()).isEqualTo(AuctionStatus.PROGRESS)
+			() -> assertThat(savedAuction2.getStatus()).isEqualTo(AuctionStatus.BIDDING),
+			() -> assertThat(savedAuction3.getStatus()).isEqualTo(AuctionStatus.BIDDING)
 		);
 	}
 }

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -3,6 +3,7 @@ package dev.handsup.auction.repository.auction;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,8 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
+import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.bookmark.domain.Bookmark;
@@ -42,7 +45,6 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 
 	private User user;
 	private ProductCategory category;
-	private Auction auction1, auction2;
 
 	@BeforeEach
 	void setUp() {
@@ -51,17 +53,16 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 
 		user = UserFixture.user();
 		userRepository.save(user);
-
-		auction1 = AuctionFixture.auction(category);
-		auction2 = AuctionFixture.auction(category);
-		auctionRepository.saveAll(List.of(auction1, auction2));
-
 	}
 
 	@DisplayName("[유저가 북마크한 경매를 모두 조회할 수 있다.]")
 	@Test
 	void findBookmarkAuction() {
 		//given
+		Auction auction1 = AuctionFixture.auction(category);
+		Auction auction2 = AuctionFixture.auction(category);
+		auctionRepository.saveAll(List.of(auction1, auction2));
+
 		Bookmark bookmark1 = BookmarkFixture.bookmark(user, auction1);
 		Bookmark bookmark2 = BookmarkFixture.bookmark(user, auction2);
 		bookmarkRepository.saveAll(List.of(bookmark1, bookmark2));
@@ -77,5 +78,30 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 			() -> assertThat(auctions.get(1)).isEqualTo(auction2)
 		);
 
+	}
+
+	@Transactional
+	@DisplayName("[특정 날짜의 이전의 특정 경매 상태를 새로운 경매 상태로 변경한다.")
+	@Test
+	void updateAuctionStatus() {
+	    //given
+		LocalDate today = LocalDate.now();
+		Auction auction1 = AuctionFixture.auction(category, today.minusDays(1));
+		Auction auction2 = AuctionFixture.auction(category, today);
+		Auction auction3 = AuctionFixture.auction(category, today.plusDays(1));
+		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
+
+		//when
+		auctionRepository.updateAuctionStatus(AuctionStatus.PROGRESS, AuctionStatus.TRADING, today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
+		Auction savedAuction1 = auctionRepository.findById(auction1.getId()).orElseThrow();
+		Auction savedAuction2 = auctionRepository.findById(auction2.getId()).orElseThrow();
+		Auction savedAuction3 = auctionRepository.findById(auction3.getId()).orElseThrow();
+
+	    //then
+		assertAll(
+			() -> assertThat(savedAuction1.getStatus()).isEqualTo(AuctionStatus.TRADING),
+			() -> assertThat(savedAuction2.getStatus()).isEqualTo(AuctionStatus.PROGRESS),
+			() -> assertThat(savedAuction3.getStatus()).isEqualTo(AuctionStatus.PROGRESS)
+		);
 	}
 }

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -150,4 +150,22 @@ public class AuctionFixture {
 			DONG
 		);
 	}
+
+	public static Auction auction(ProductCategory productCategory, LocalDate endDate) {
+		return Auction.of(
+			UserFixture.user(),
+			TITLE,
+			productCategory,
+			10000,
+			endDate,
+			ProductStatus.NEW,
+			PurchaseTime.UNDER_ONE_MONTH,
+			DESCRIPTION,
+			TradeMethod.DIRECT,
+			List.of("image.jpg"),
+			SI,
+			GU,
+			DONG
+		);
+	}
 }


### PR DESCRIPTION
close #51 
### 📑 작업 상세 내용
- 스케줄러 구현
  - 스케줄러 설정 추가
- 경매 상태 벌크 연산 repository 함수 추가 및 테스트
- 피그마 반영해 AuctionStatus 수정
  - PROGRESS -> BIDDING
  - label 수정

### 💫 작업 요약

- 경매 상태 변경 함수 추가 및 스케줄러 구현

### 🔍 중점적으로 리뷰 할 부분

- AuctionRepository
- AuctionScheduler