### PR TITLE
[feat] : Bidding 응답값 추가

### DIFF
--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -70,7 +70,9 @@ class BiddingApiControllerTest extends ApiTestSupport {
 			status().isOk(),
 			jsonPath("$.biddingPrice").value(10000),
 			jsonPath("$.auctionId").value(auction.getId()),
-			jsonPath("$.bidderNickname").value(user.getNickname())
+			jsonPath("$.bidderId").value(user.getId()),
+			jsonPath("$.bidderNickname").value(user.getNickname()),
+			jsonPath("$.imgUrl").value(auction.getProduct().getImages().get(0).getImageUrl())
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
@@ -24,7 +24,9 @@ public class BiddingMapper {
 			bidding.getBiddingPrice(),
 			bidding.getAuction().getId(),
 			bidding.getBidder().getId(),
-			bidding.getBidder().getNickname()
+			bidding.getBidder().getNickname(),
+			bidding.getAuction().getProduct().getImages().get(0).getImageUrl(),
+			bidding.getCreatedAt().toString()
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/bidding/dto/response/BiddingResponse.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/response/BiddingResponse.java
@@ -9,19 +9,25 @@ public record BiddingResponse(
 	int biddingPrice,
 	Long auctionId,
 	Long bidderId,
-	String bidderNickname
+	String bidderNickname,
+	String imgUrl,
+	String createdAt
 ) {
 	public static BiddingResponse of(
 		int biddingPrice,
 		Long auctionId,
 		Long bidderId,
-		String bidderNickname
+		String bidderNickname,
+		String imgUrl,
+		String createdAt
 	) {
 		return BiddingResponse.builder()
 			.biddingPrice(biddingPrice)
 			.auctionId(auctionId)
 			.bidderId(bidderId)
 			.bidderNickname(bidderNickname)
+			.imgUrl(imgUrl)
+			.createdAt(createdAt)
 			.build();
 	}
 }

--- a/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
+++ b/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
@@ -17,6 +18,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.service.AuctionService;
@@ -88,6 +90,7 @@ class BiddingServiceTest {
 			auction,
 			user
 		);
+		ReflectionTestUtils.setField(bidding, "createdAt", LocalDateTime.now());
 		given(biddingRepository.save(any(Bidding.class))).willReturn(bidding);
 		given(biddingRepository.findMaxBiddingPriceByAuctionId(any(Long.class))).willReturn(19000);
 
@@ -106,12 +109,18 @@ class BiddingServiceTest {
 		Long auctionId = 1L;
 		Pageable pageRequest = PageRequest.of(0, 10);
 
+		Bidding bidding1 = Bidding.of(40000, auction, user);
+		Bidding bidding2 = Bidding.of(30000, auction, user);
+		Bidding bidding3 = Bidding.of(20000, auction, user);
 		List<Bidding> mockBiddingList = List.of(
-			Bidding.of(40000, auction, user),
-			Bidding.of(30000, auction, user),
-			Bidding.of(20000, auction, user)
+			bidding1,
+			bidding2,
+			bidding3
 		);
 		Slice<Bidding> mockSlice = new SliceImpl<>(mockBiddingList, pageRequest, true);
+		ReflectionTestUtils.setField(bidding1, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(bidding2, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(bidding3, "createdAt", LocalDateTime.now());
 
 		given(biddingRepository.findByAuctionIdOrderByBiddingPriceDesc(auctionId, pageRequest))
 			.willReturn(mockSlice);


### PR DESCRIPTION
close #53 

### 📑 작업 상세 내용

- BiddingResponse 에 Auction 의 첫번째 ImgUrl, 입찰 등록시간인 createAt 을 추가

### 💫 작업 요약

- Bidding 응답값 추가

### 🔍 중점적으로 리뷰 할 부분

- BiddingMapper