### PR TITLE
[feat] : 회원 탈퇴 API

### DIFF
--- a/api/src/main/java/dev/handsup/review/controller/ReviewApiController.java
+++ b/api/src/main/java/dev/handsup/review/controller/ReviewApiController.java
@@ -16,6 +16,7 @@ import dev.handsup.review.dto.response.ReviewResponse;
 import dev.handsup.review.service.ReviewService;
 import dev.handsup.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -35,7 +36,7 @@ public class ReviewApiController {
 	public ResponseEntity<ReviewResponse> registerReview(
 		@Valid @RequestBody RegisterReviewRequest request,
 		@PathVariable Long auctionId,
-		@JwtAuthorization User writer
+		@Parameter(hidden = true) @JwtAuthorization User writer
 	) {
 		ReviewResponse response = reviewService.registerReview(
 			request,

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -2,6 +2,7 @@ package dev.handsup.user.controller;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,7 +10,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.auth.jwt.JwtAuthorization;
 import dev.handsup.common.dto.PageResponse;
+import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.request.EmailAvailibilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
@@ -17,6 +20,7 @@ import dev.handsup.user.dto.response.JoinUserResponse;
 import dev.handsup.user.dto.response.UserReviewLabelResponse;
 import dev.handsup.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -61,5 +65,14 @@ public class UserApiController {
 	) {
 		PageResponse<UserReviewLabelResponse> response = userService.getUserReviewLabels(userId, pageable);
 		return ResponseEntity.ok(response);
+	}
+
+	@DeleteMapping("/api/users")
+	@Operation(summary = "사용자 정보 삭제 API", description = "특정 사용자의 정보를 삭제한다")
+	public ResponseEntity<Void> deleteUser(
+		@Parameter(hidden = true) @JwtAuthorization User user
+	) {
+		userService.deleteUser(user);
+		return ResponseEntity.noContent().build();
 	}
 }

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -1,6 +1,7 @@
 package dev.handsup.user.controller;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.springframework.http.HttpHeaders.*;
 import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -14,10 +15,12 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import dev.handsup.common.support.ApiTestSupport;
+import dev.handsup.fixture.UserFixture;
 import dev.handsup.review.domain.ReviewLabel;
 import dev.handsup.review.domain.ReviewLabelValue;
 import dev.handsup.review.domain.UserReviewLabel;
 import dev.handsup.review.repository.ReviewLabelRepository;
+import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.request.EmailAvailibilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.repository.UserRepository;
@@ -102,6 +105,7 @@ class UserApiControllerTest extends ApiTestSupport {
 		actions.andExpect(status().isOk())
 			.andExpect(jsonPath("$.isAvailable").value(false));
 	}
+
 	@Test
 	@DisplayName("[[유저 리뷰 라벨 조회 API] 유저의 리뷰 라벨이 id 기준 오름차순으로 반환된다]")
 	void getUserReviewLabelsTest() throws Exception {
@@ -127,5 +131,18 @@ class UserApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.content[1].reviewLabelId").value(reviewLabel2.getId()))
 			.andExpect(jsonPath("$.content[1].userId").value(user.getId()))
 			.andExpect(jsonPath("$.content[1].count").value(1));
+	}
+
+	@Test
+	@DisplayName("[[사용자 정보 삭제 API] 특정 사용자의 정보를 삭제한다]")
+	void deleteUserTest() throws Exception {
+		//given
+		User forDeleteUser = UserFixture.user("hello223@naver.com");
+		userRepository.save(forDeleteUser);
+
+		//when & then
+		mockMvc.perform(delete("/api/users")
+				.header(AUTHORIZATION, "Bearer " + accessToken))
+			.andExpect(status().isNoContent());
 	}
 }

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -85,4 +85,12 @@ public class UserService {
 		return productCategoryRepository.findById(productCategoryId)
 			.orElseThrow(() -> new NotFoundException(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY));
 	}
+
+	@Transactional
+	public void deleteUser(User user) {
+		if (!userRepository.existsById(user.getId())) {
+			throw new NotFoundException(UserErrorCode.NOT_FOUND_USER);
+		}
+		userRepository.deleteById(user.getId());
+	}
 }


### PR DESCRIPTION
close #67 

### 📑 작업 상세 내용

- 회원 탈퇴 할수있는는 service 메서드와 API 를 개발했습니다.
- 요청이 성공적으로 처리되었으나, 클라이언트에게 전달할 추가 콘텐츠가 없다는 204
`ResponseEntity.noContent().build();` 를 반환합니다.
- UserService 의 deleteUser() 에서 exists() 를 합니다. `@JwtAuthrizaion` 에서 이미 토큰 검사를 하기때문에 필요 없을 수도 있지만 버그 방지차원에서 한 번 더 검사하긴 했습니다.
- `사용자와 관련된 경매, 댓글, 채팅방, 등등 다 삭제해야 합니다. (보류)`

### 💫 작업 요약

- 회원 탈퇴

### 🔍 중점적으로 리뷰 할 부분

- UserApiController
- UserService