### PR TITLE
[feat] : 사용자 리뷰 조회 API

### DIFF
--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -15,6 +15,7 @@ import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.JoinUserResponse;
 import dev.handsup.user.dto.response.UserReviewLabelResponse;
+import dev.handsup.user.dto.response.UserReviewResponse;
 import dev.handsup.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -60,6 +61,18 @@ public class UserApiController {
 		Pageable pageable
 	) {
 		PageResponse<UserReviewLabelResponse> response = userService.getUserReviewLabels(userId, pageable);
+		return ResponseEntity.ok(response);
+	}
+
+	@NoAuth
+	@GetMapping("/api/users/{userId}/reviews")
+	@Operation(summary = "유저 리뷰 조회 API", description = "특정 유저의 리뷰를 조회한다")
+	@ApiResponse(useReturnTypeSchema = true)
+	public ResponseEntity<PageResponse<UserReviewResponse>> getUserReviews(
+		@PathVariable Long userId,
+		Pageable pageable
+	) {
+		PageResponse<UserReviewResponse> response = userService.getUserReviews(userId, pageable);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/core/src/main/java/dev/handsup/review/exception/ReviewErrorCode.java
+++ b/core/src/main/java/dev/handsup/review/exception/ReviewErrorCode.java
@@ -7,7 +7,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ReviewErrorCode implements ErrorCode {
+
 	NOT_FOUND_REVIEW_LABEL("해당 아이디의 리뷰 라벨이 존재하지 않습니다.", "RL_000");
+
 	private final String message;
 	private final String code;
 }

--- a/core/src/main/java/dev/handsup/review/repository/ReviewRepository.java
+++ b/core/src/main/java/dev/handsup/review/repository/ReviewRepository.java
@@ -8,4 +8,6 @@ import dev.handsup.review.domain.Review;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
 	Slice<Review> findByAuctionIdOrderByCreatedAtDesc(Long auctionId, Pageable pageable);
+
+	Slice<Review> findByAuction_Seller_IdOrderByCreatedAtDesc(Long sellerId, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/user/dto/UserMapper.java
+++ b/core/src/main/java/dev/handsup/user/dto/UserMapper.java
@@ -3,11 +3,13 @@ package dev.handsup.user.dto;
 import static lombok.AccessLevel.*;
 
 import dev.handsup.auth.domain.EncryptHelper;
+import dev.handsup.review.domain.Review;
 import dev.handsup.review.domain.UserReviewLabel;
 import dev.handsup.user.domain.Address;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.UserReviewLabelResponse;
+import dev.handsup.user.dto.response.UserReviewResponse;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
@@ -33,6 +35,14 @@ public class UserMapper {
 			userReviewLabel.getReviewLabel().getId(),
 			userReviewLabel.getUser().getId(),
 			userReviewLabel.getCount()
+		);
+	}
+
+	public static UserReviewResponse toUserReviewResponse(Review review) {
+		return UserReviewResponse.of(
+			review.getWriter().getNickname(),
+			review.getWriter().getProfileImageUrl(),
+			review.getContent()
 		);
 	}
 }

--- a/core/src/main/java/dev/handsup/user/dto/UserMapper.java
+++ b/core/src/main/java/dev/handsup/user/dto/UserMapper.java
@@ -40,6 +40,7 @@ public class UserMapper {
 
 	public static UserReviewResponse toUserReviewResponse(Review review) {
 		return UserReviewResponse.of(
+			review.getId(),
 			review.getWriter().getNickname(),
 			review.getWriter().getProfileImageUrl(),
 			review.getContent()

--- a/core/src/main/java/dev/handsup/user/dto/response/UserReviewResponse.java
+++ b/core/src/main/java/dev/handsup/user/dto/response/UserReviewResponse.java
@@ -2,16 +2,19 @@ package dev.handsup.user.dto.response;
 
 public record UserReviewResponse(
 
+	Long reviewId,
 	String writerNickName,
 	String writerProfileImageUrl,
 	String content
 ) {
 	public static UserReviewResponse of(
+		Long reviewId,
 		String writerNickName,
 		String writerProfileImageUrl,
 		String content
 	) {
 		return new UserReviewResponse(
+			reviewId,
 			writerNickName,
 			writerProfileImageUrl,
 			content

--- a/core/src/main/java/dev/handsup/user/dto/response/UserReviewResponse.java
+++ b/core/src/main/java/dev/handsup/user/dto/response/UserReviewResponse.java
@@ -1,0 +1,20 @@
+package dev.handsup.user.dto.response;
+
+public record UserReviewResponse(
+
+	String writerNickName,
+	String writerProfileImageUrl,
+	String content
+) {
+	public static UserReviewResponse of(
+		String writerNickName,
+		String writerProfileImageUrl,
+		String content
+	) {
+		return new UserReviewResponse(
+			writerNickName,
+			writerProfileImageUrl,
+			content
+		);
+	}
+}

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -15,12 +15,14 @@ import dev.handsup.common.dto.CommonMapper;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.common.exception.ValidationException;
+import dev.handsup.review.repository.ReviewRepository;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.UserMapper;
 import dev.handsup.user.dto.request.EmailAvailibilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.UserReviewLabelResponse;
+import dev.handsup.user.dto.response.UserReviewResponse;
 import dev.handsup.user.exception.UserErrorCode;
 import dev.handsup.user.repository.UserRepository;
 import dev.handsup.user.repository.UserReviewLabelRepository;
@@ -35,6 +37,7 @@ public class UserService {
 	private final PreferredProductCategoryRepository preferredProductCategoryRepository;
 	private final ProductCategoryRepository productCategoryRepository;
 	private final UserReviewLabelRepository userReviewLabelRepository;
+	private final ReviewRepository reviewRepository;
 
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.findByEmail(email).isPresent()) {
@@ -84,5 +87,13 @@ public class UserService {
 	public ProductCategory getProductCategoryById(Long productCategoryId) {
 		return productCategoryRepository.findById(productCategoryId)
 			.orElseThrow(() -> new NotFoundException(AuctionErrorCode.NOT_FOUND_PRODUCT_CATEGORY));
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse<UserReviewResponse> getUserReviews(Long userId, Pageable pageable) {
+		Slice<UserReviewResponse> userReviewResponsePage = reviewRepository
+			.findByAuction_Seller_IdOrderByCreatedAtDesc(userId, pageable)
+			.map(UserMapper::toUserReviewResponse);
+		return CommonMapper.toPageResponse(userReviewResponsePage);
 	}
 }

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -64,25 +64,6 @@ public class AuctionFixture {
 		);
 	}
 
-	public static Auction auction(User seller) {
-		return Auction.of(
-			1L,
-			seller,
-			TITLE,
-			ProductCategory.of(DIGITAL_DEVICE),
-			10000,
-			LocalDate.parse(END_DATE),
-			ProductStatus.NEW,
-			PurchaseTime.UNDER_ONE_MONTH,
-			DESCRIPTION,
-			TradeMethod.DELIVER,
-			List.of("image.jpg"),
-			SI,
-			GU,
-			DONG
-		);
-	}
-
 	public static Auction auction(ProductCategory productCategory) {
 		return Auction.of(
 			UserFixture.user(),
@@ -113,7 +94,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DELIVER,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -10,6 +10,7 @@ import dev.handsup.auction.domain.auction_field.PurchaseTime;
 import dev.handsup.auction.domain.auction_field.TradeMethod;
 import dev.handsup.auction.domain.product.ProductStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.user.domain.User;
 import lombok.NoArgsConstructor;
 
 @NoArgsConstructor(access = PRIVATE)
@@ -22,6 +23,7 @@ public class AuctionFixture {
 	static final String SI = "서울시";
 	static final String GU = "성북구";
 	static final String DONG = "동선동";
+	static final String IMAGE_URL = "image.jpg";
 
 	// 아이디 지정한 기본 auction
 	public static Auction auction() {
@@ -36,7 +38,26 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DELIVER,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
+			SI,
+			GU,
+			DONG
+		);
+	}
+
+	public static Auction auction(User seller) {
+		return Auction.of(
+			1L,
+			seller,
+			TITLE,
+			ProductCategory.of(DIGITAL_DEVICE),
+			10000,
+			LocalDate.parse(END_DATE),
+			ProductStatus.NEW,
+			PurchaseTime.UNDER_ONE_MONTH,
+			DESCRIPTION,
+			TradeMethod.DELIVER,
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -54,7 +75,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DELIVER,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -72,7 +93,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DELIVER,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -90,7 +111,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DELIVER,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -108,7 +129,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			tradeMethod,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -126,7 +147,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DIRECT,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -144,7 +165,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DIRECT,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
@@ -162,7 +183,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DIRECT,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			si,
 			gu,
 			dong
@@ -180,7 +201,7 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DIRECT,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			si,
 			gu,
 			dong
@@ -198,10 +219,11 @@ public class AuctionFixture {
 			PurchaseTime.UNDER_ONE_MONTH,
 			DESCRIPTION,
 			TradeMethod.DIRECT,
-			List.of("image.jpg"),
+			List.of(IMAGE_URL),
 			SI,
 			GU,
 			DONG
 		);
 	}
+
 }

--- a/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
@@ -19,11 +19,11 @@ public final class ReviewFixture {
 		return Review.of(EVALUATION_SCORE, CONTENT, AUCTION, WRITER);
 	}
 
-	public static Review review(int evaluationScore) {
-		return Review.of(evaluationScore, CONTENT, AUCTION, WRITER);
-	}
-
 	public static Review review(String content, Auction auction) {
 		return Review.of(EVALUATION_SCORE, content, auction, WRITER);
+	}
+
+	public static Review review(String content, Auction auction, User writer) {
+		return Review.of(EVALUATION_SCORE, content, auction, writer);
 	}
 }


### PR DESCRIPTION
close #68 

### 📑 작업 상세 내용

-  사용자 리뷰 조회를 하면 UserReviewResponse 에서 작성자 닉네임 / 작성자 프로필 이미지 / 작성 내용 을 반환합니다.
- 조회되는 리뷰는 최신 생성순으로 정렬되었습니다.
- Auction, Review 의 Fixture 메서드 추가

### 💫 작업 요약

- 사용자 리뷰 조회 API

### 🔍 중점적으로 리뷰 할 부분

- UserApiController
- UserApiControllerTest
- UserService