### PR TITLE
[feat] : 채팅방 메시지 조회, 채팅방 메시지 읽음 처리

### DIFF
--- a/api/src/main/java/dev/handsup/chat/controller/ChatRoomApiController.java
+++ b/api/src/main/java/dev/handsup/chat/controller/ChatRoomApiController.java
@@ -81,11 +81,9 @@ public class ChatRoomApiController {
 	@GetMapping("/{chatRoomId}/messages")
 	public ResponseEntity<PageResponse<ChatMessageResponse>> getChatRoomMessages(
 		@PathVariable("chatRoomId") Long chatRoomId,
-		@Parameter(hidden = true) @JwtAuthorization User user,
 		Pageable pageable
 	) {
-		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(chatRoomId, user,
-			pageable);
+		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(chatRoomId, pageable);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/api/src/main/java/dev/handsup/chat/controller/ChatRoomApiController.java
+++ b/api/src/main/java/dev/handsup/chat/controller/ChatRoomApiController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.handsup.auth.jwt.JwtAuthorization;
+import dev.handsup.chat.dto.response.ChatMessageResponse;
 import dev.handsup.chat.dto.response.ChatRoomDetailResponse;
 import dev.handsup.chat.dto.response.ChatRoomSimpleResponse;
 import dev.handsup.chat.dto.response.RegisterChatRoomResponse;
@@ -72,6 +73,19 @@ public class ChatRoomApiController {
 		@Parameter(hidden = true) @JwtAuthorization User user
 	) {
 		ChatRoomDetailResponse response = chatRoomService.getChatRoomWithBiddingId(biddingId, user);
+		return ResponseEntity.ok(response);
+	}
+
+	@Operation(summary = "채팅방 아이디로 채팅 메시지 조회", description = "채팅방 아이디로 채팅 메시지를 슬라이스하여 가져온다.")
+	@ApiResponse(useReturnTypeSchema = true)
+	@GetMapping("/{chatRoomId}/messages")
+	public ResponseEntity<PageResponse<ChatMessageResponse>> getChatRoomMessages(
+		@PathVariable("chatRoomId") Long chatRoomId,
+		@Parameter(hidden = true) @JwtAuthorization User user,
+		Pageable pageable
+	) {
+		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(chatRoomId, user,
+			pageable);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -32,9 +32,9 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 
 	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	private final User user = UserFixture.user();
 	private final User seller = UserFixture.user("seller@naver.com");
+	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
@@ -33,9 +32,9 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 
 	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
+	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	private final User user = UserFixture.user();
 	private final User seller = UserFixture.user("seller@naver.com");
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired

--- a/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
@@ -21,12 +21,15 @@ import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.repository.BiddingRepository;
+import dev.handsup.chat.domain.ChatMessage;
 import dev.handsup.chat.domain.ChatRoom;
 import dev.handsup.chat.exception.ChatRoomErrorCode;
+import dev.handsup.chat.repository.ChatMessageRepository;
 import dev.handsup.chat.repository.ChatRoomRepository;
 import dev.handsup.common.support.ApiTestSupport;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.BiddingFixture;
+import dev.handsup.fixture.ChatMessageFixture;
 import dev.handsup.fixture.ChatRoomFixture;
 import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
@@ -49,6 +52,8 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 	private BiddingRepository biddingRepository;
 	@Autowired
 	private ChatRoomRepository chatRoomRepository;
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -179,7 +184,6 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 	@Test
 	void getChatRoomWithBiddingId() throws Exception {
 		//given
-		biddingRepository.save(bidding);
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 		chatRoomRepository.save(chatRoom);
 		//when, then
@@ -216,5 +220,34 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isBadRequest())
 			.andDo(MockMvcResultHandlers.print());
+	}
+
+	@DisplayName("[채팅방 아이디로 채팅 메시지를 모두 조회할 수 있다.]")
+	@Test
+	void getChatRoomMessages() throws Exception {
+	    //given
+		ChatRoom chatRoom1 = ChatRoomFixture.chatRoom(seller, bidding);
+		ChatRoom chatRoom2 = ChatRoomFixture.chatRoom(seller, bidding);
+		chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
+
+		ChatMessage chatMessage1 = ChatMessageFixture.chatMessage(chatRoom1, bidder);
+		ChatMessage chatMessage2 = ChatMessageFixture.chatMessage(chatRoom1, seller);
+		ChatMessage otherChatMessage3 = ChatMessageFixture.chatMessage(chatRoom2, seller);
+		chatMessageRepository.saveAll(List.of(chatMessage1, chatMessage2, otherChatMessage3));
+
+	    //when, then
+		mockMvc.perform(get("/api/auctions/chat-rooms/{chatRoomId}/messages", bidding.getId())
+				.header(AUTHORIZATION, "Bearer " + accessToken)
+				.contentType(APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.size").value(2))
+			.andExpect(jsonPath("$.content[0].chatRoomId").value(chatMessage1.getChatRoom().getId()))
+			.andExpect(jsonPath("$.content[0].content").value(chatMessage1.getContent()))
+			.andExpect(jsonPath("$.content[0].senderId").value(chatMessage1.getSenderId()))
+			.andExpect(jsonPath("$.content[0].content").value(chatMessage1.getContent()))
+			.andExpect(jsonPath("$.content[1].chatRoomId").value(chatMessage2.getChatRoom().getId()))
+			.andExpect(jsonPath("$.content[1].content").value(chatMessage2.getContent()))
+			.andExpect(jsonPath("$.content[1].senderId").value(chatMessage2.getSenderId()))
+			.andExpect(jsonPath("$.content[1].content").value(chatMessage2.getContent()));
 	}
 }

--- a/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
@@ -225,7 +225,7 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 	@DisplayName("[채팅방 아이디로 채팅 메시지를 모두 조회할 수 있다.]")
 	@Test
 	void getChatRoomMessages() throws Exception {
-	    //given
+		//given
 		ChatRoom chatRoom1 = ChatRoomFixture.chatRoom(seller, bidding);
 		ChatRoom chatRoom2 = ChatRoomFixture.chatRoom(seller, bidding);
 		chatRoomRepository.saveAll(List.of(chatRoom1, chatRoom2));
@@ -235,7 +235,7 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 		ChatMessage otherChatMessage3 = ChatMessageFixture.chatMessage(chatRoom2, seller);
 		chatMessageRepository.saveAll(List.of(chatMessage1, chatMessage2, otherChatMessage3));
 
-	    //when, then
+		//when, then
 		mockMvc.perform(get("/api/auctions/chat-rooms/{chatRoomId}/messages", bidding.getId())
 				.header(AUTHORIZATION, "Bearer " + accessToken)
 				.contentType(APPLICATION_JSON))

--- a/api/src/test/java/dev/handsup/chat/controller/WebSocketTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/WebSocketTest.java
@@ -105,7 +105,8 @@ class WebSocketTest extends ApiTestSupport {
 		stompSession.subscribe("/sub/chat-rooms/" + chatRoom.getId(),
 			new StompFrameHandlerImpl<>(ChatMessageResponse.class, chatMessageResponses));
 
-		ChatMessageResponse expected = ChatMessageResponse.from(chatMessage);
+		ChatMessageResponse expected = ChatMessageResponse.of(chatMessage.getChatRoom().getId(),
+			chatMessage.getSenderId(), chatMessage.getContent(), chatMessage.getCreatedAt().toString());
 
 		// when
 		stompSession.send("/pub/chat-rooms/" + chatRoom.getId(), request);

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -6,11 +6,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
+
+	@Query("SELECT b FROM Bidding b "
+		+ "JOIN FETCH b.auction "
+		+ "JOIN FETCH b.bidder "
+		+ "WHERE b.id = :id")
+	Optional<Bidding> findBiddingWithAuctionAndBidder(@Param("id") Long id);
 
 	@Query("SELECT MAX(b.biddingPrice) FROM Bidding b WHERE b.auction.id = :auctionId")
 	Integer findMaxBiddingPriceByAuctionId(Long auctionId);

--- a/core/src/main/java/dev/handsup/chat/dto/ChatMessageMapper.java
+++ b/core/src/main/java/dev/handsup/chat/dto/ChatMessageMapper.java
@@ -16,6 +16,11 @@ public class ChatMessageMapper {
 	}
 
 	public static ChatMessageResponse toChatMessageResponse(ChatMessage chatMessage) {
-		return ChatMessageResponse.from(chatMessage);
+		return ChatMessageResponse.of(
+			chatMessage.getChatRoom().getId(),
+			chatMessage.getSenderId(),
+			chatMessage.getContent(),
+			chatMessage.getCreatedAt().toString()
+		);
 	}
 }

--- a/core/src/main/java/dev/handsup/chat/dto/response/ChatMessageResponse.java
+++ b/core/src/main/java/dev/handsup/chat/dto/response/ChatMessageResponse.java
@@ -1,19 +1,19 @@
 package dev.handsup.chat.dto.response;
 
-import dev.handsup.chat.domain.ChatMessage;
-
 public record ChatMessageResponse(
 	Long chatRoomId,
 	Long senderId,
 	String content,
 	String createdAt
 ) {
-	public static ChatMessageResponse from(ChatMessage chatMessage) {
+	public static ChatMessageResponse of(
+		Long chatRoomId,
+		Long senderId,
+		String content,
+		String createdAt
+	) {
 		return new ChatMessageResponse(
-			chatMessage.getChatRoom().getId(),
-			chatMessage.getSenderId(),
-			chatMessage.getContent(),
-			chatMessage.getCreatedAt().toString()
+			chatRoomId, senderId, content, createdAt
 		);
 	}
 }

--- a/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
+++ b/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
@@ -12,7 +12,9 @@ public enum ChatRoomErrorCode implements ErrorCode {
 	NOT_TRADING_AUCTION("거래 상태의 경매가 아닙니다.", "CR_002"),
 	CHAT_ROOM_ACCESS_DENIED("채팅방 조회 권한이 없습니다.", "CR_003"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CR_004"),
-	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005");
+	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005"),
+	CHAT_MESSAGE_ACCESS_DENIED("채팅메시지 조회 권한이 없습니다.", "CR_006");
+
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
+++ b/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
@@ -12,8 +12,7 @@ public enum ChatRoomErrorCode implements ErrorCode {
 	NOT_TRADING_AUCTION("거래 상태의 경매가 아닙니다.", "CR_002"),
 	CHAT_ROOM_ACCESS_DENIED("채팅방 조회 권한이 없습니다.", "CR_003"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CR_004"),
-	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005"),
-	CHAT_MESSAGE_ACCESS_DENIED("채팅메시지 조회 권한이 없습니다.", "CR_006");
+	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
+++ b/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
@@ -15,7 +15,6 @@ public enum ChatRoomErrorCode implements ErrorCode {
 	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005"),
 	CHAT_MESSAGE_ACCESS_DENIED("채팅메시지 조회 권한이 없습니다.", "CR_006");
 
-
 	private final String message;
 	private final String code;
 }

--- a/core/src/main/java/dev/handsup/chat/repository/ChatMessageRepository.java
+++ b/core/src/main/java/dev/handsup/chat/repository/ChatMessageRepository.java
@@ -3,10 +3,24 @@ package dev.handsup.chat.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import dev.handsup.chat.domain.ChatMessage;
 import dev.handsup.chat.domain.ChatRoom;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
 	Slice<ChatMessage> findByChatRoomOrderByCreatedAt(ChatRoom chatRoom, Pageable pageable);
+
+	@Modifying(flushAutomatically = true, clearAutomatically = true)
+	@Query(
+		"update ChatMessage m set m.isRead = true "
+			+ "where m.chatRoom = :chatRoom "
+			+ "and m.senderId != :senderId"
+	)
+	void readReceivedMessages(
+		@Param("chatRoom") ChatRoom chatRoom,
+		@Param("senderId") Long senderId
+	);
 }

--- a/core/src/main/java/dev/handsup/chat/repository/ChatMessageRepository.java
+++ b/core/src/main/java/dev/handsup/chat/repository/ChatMessageRepository.java
@@ -1,8 +1,12 @@
 package dev.handsup.chat.repository;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import dev.handsup.chat.domain.ChatMessage;
+import dev.handsup.chat.domain.ChatRoom;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+	Slice<ChatMessage> findByChatRoomOrderByCreatedAt(ChatRoom chatRoom, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -69,25 +69,21 @@ public class ChatRoomService {
 	}
 
 	// 채팅 목록에서 조회
-	@Transactional
+	@Transactional(readOnly = true)
 	public ChatRoomDetailResponse getChatRoomWithId(Long chatRoomId, User user) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		Bidding currentBidding = getBiddingById(chatRoom.getCurrentBiddingId());
 		User receiver = getReceiver(user, chatRoom);
-		chatMessageRepository.readReceivedMessages(chatRoom, user.getId());
-
 		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, currentBidding, receiver);
 	}
 
 	// 입찰자 목록에서 조회
-	@Transactional
+	@Transactional(readOnly = true)
 	public ChatRoomDetailResponse getChatRoomWithBiddingId(Long biddingId, User user) {
 		Bidding bidding = getBiddingById(biddingId);
 		validateAuthorization(user, bidding);
 		User receiver = bidding.getBidder();
 		ChatRoom chatRoom = getChatRoomByCurrentBidding(bidding);
-		chatMessageRepository.readReceivedMessages(chatRoom, user.getId());
-
 		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, bidding, receiver);
 	}
 

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -92,7 +92,7 @@ public class ChatRoomService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<ChatMessageResponse> getChatRoomMessages(Long chatRoomId, User user, Pageable pageable) {
+	public PageResponse<ChatMessageResponse> getChatRoomMessages(Long chatRoomId,Pageable pageable) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		Slice<ChatMessageResponse> responsePage = chatMessageRepository
 			.findByChatRoomOrderByCreatedAt(chatRoom, pageable)

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -69,18 +69,18 @@ public class ChatRoomService {
 	}
 
 	// 채팅 목록에서 조회
-	@Transactional(readOnly = true)
+	@Transactional
 	public ChatRoomDetailResponse getChatRoomWithId(Long chatRoomId, User user) {
 		ChatRoom chatRoom = getChatRoomById(chatRoomId);
 		Bidding currentBidding = getBiddingById(chatRoom.getCurrentBiddingId());
-		chatMessageRepository.readReceivedMessages(chatRoom, user.getId());
 		User receiver = getReceiver(user, chatRoom);
+		chatMessageRepository.readReceivedMessages(chatRoom, user.getId());
 
 		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, currentBidding, receiver);
 	}
 
 	// 입찰자 목록에서 조회
-	@Transactional(readOnly = true)
+	@Transactional
 	public ChatRoomDetailResponse getChatRoomWithBiddingId(Long biddingId, User user) {
 		Bidding bidding = getBiddingById(biddingId);
 		validateAuthorization(user, bidding);
@@ -121,7 +121,7 @@ public class ChatRoomService {
 	}
 
 	private Bidding getBiddingById(Long biddingId) {
-		return biddingRepository.findById(biddingId)
+		return biddingRepository.findBiddingWithAuctionAndBidder(biddingId)
 			.orElseThrow(() -> new NotFoundException(BiddingErrorCode.NOT_FOUND_BIDDING));
 	}
 

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -13,11 +13,14 @@ import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.exception.BiddingErrorCode;
 import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.chat.domain.ChatRoom;
+import dev.handsup.chat.dto.ChatMessageMapper;
 import dev.handsup.chat.dto.ChatRoomMapper;
+import dev.handsup.chat.dto.response.ChatMessageResponse;
 import dev.handsup.chat.dto.response.ChatRoomDetailResponse;
 import dev.handsup.chat.dto.response.ChatRoomSimpleResponse;
 import dev.handsup.chat.dto.response.RegisterChatRoomResponse;
 import dev.handsup.chat.exception.ChatRoomErrorCode;
+import dev.handsup.chat.repository.ChatMessageRepository;
 import dev.handsup.chat.repository.ChatRoomRepository;
 import dev.handsup.common.dto.CommonMapper;
 import dev.handsup.common.dto.PageResponse;
@@ -31,6 +34,7 @@ import lombok.RequiredArgsConstructor;
 public class ChatRoomService {
 
 	private final ChatRoomRepository chatRoomRepository;
+	private final ChatMessageRepository chatMessageRepository;
 	private final BiddingRepository biddingRepository;
 
 	@Transactional
@@ -83,6 +87,15 @@ public class ChatRoomService {
 		ChatRoom chatRoom = getChatRoomByCurrentBidding(bidding);
 
 		return ChatRoomMapper.toChatRoomDetailResponse(chatRoom, bidding, receiver);
+	}
+
+	@Transactional(readOnly = true)
+	public PageResponse<ChatMessageResponse> getChatRoomMessages(Long chatRoomId, Pageable pageable){
+		ChatRoom chatRoom = getChatRoomById(chatRoomId);
+		Slice<ChatMessageResponse> responsePage = chatMessageRepository
+			.findByChatRoomOrderByCreatedAt(chatRoom, pageable)
+			.map(ChatMessageMapper::toChatMessageResponse);
+		return CommonMapper.toPageResponse(responsePage);
 	}
 
 	private ChatRoom getChatRoomByCurrentBidding(Bidding currentBidding) {

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -37,6 +37,14 @@ public class ChatRoomService {
 	private final ChatMessageRepository chatMessageRepository;
 	private final BiddingRepository biddingRepository;
 
+	// 채팅방 메시지 조회 권한
+	private static void validateAuthorization(User user, ChatRoom chatRoom) {
+		if (!(Objects.equals(chatRoom.getSeller().getId(), user.getId()) || Objects.equals(chatRoom.getBidder().getId(),
+			user.getId()))) {
+			throw new ValidationException(ChatRoomErrorCode.CHAT_MESSAGE_ACCESS_DENIED);
+		}
+	}
+
 	@Transactional
 	public RegisterChatRoomResponse registerChatRoom(Long auctionId, Long biddingId, User user) {
 		Bidding bidding = getBiddingById(biddingId);
@@ -109,14 +117,6 @@ public class ChatRoomService {
 		User seller = bidding.getAuction().getSeller();
 		if (!Objects.equals(user.getId(), seller.getId())) { // 조회자와 경매 판매자가 같은지
 			throw new ValidationException(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED);
-		}
-	}
-
-	// 채팅방 메시지 조회 권한
-	private static void validateAuthorization(User user, ChatRoom chatRoom) {
-		if (!(Objects.equals(chatRoom.getSeller().getId(), user.getId()) || Objects.equals(chatRoom.getBidder().getId(),
-			user.getId()))) {
-			throw new ValidationException(ChatRoomErrorCode.CHAT_MESSAGE_ACCESS_DENIED);
 		}
 	}
 

--- a/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
@@ -50,8 +50,8 @@ class ChatMessageRepositoryTest extends DataJpaTestSupport {
 
 	@BeforeEach
 	void setUp() {
-		seller = userRepository.save(UserFixture.user("seller@gmail.com"));
-		bidder = userRepository.save(UserFixture.user("buyer@gmail.com"));
+		seller = userRepository.save(UserFixture.user1());
+		bidder = userRepository.save(UserFixture.user2());
 		ProductCategory category = productCategoryRepository.save(ProductFixture.productCategory("디지털 기기"));
 		Auction auction = auctionRepository.save(AuctionFixture.auction(category));
 		Bidding bidding = biddingRepository.save(BiddingFixture.bidding(auction, bidder, TradingStatus.PREPARING));

--- a/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
@@ -1,0 +1,82 @@
+package dev.handsup.chat.repository;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.auction.repository.auction.AuctionRepository;
+import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.domain.TradingStatus;
+import dev.handsup.bidding.repository.BiddingRepository;
+import dev.handsup.chat.domain.ChatMessage;
+import dev.handsup.chat.domain.ChatRoom;
+import dev.handsup.common.support.DataJpaTestSupport;
+import dev.handsup.fixture.AuctionFixture;
+import dev.handsup.fixture.BiddingFixture;
+import dev.handsup.fixture.ChatMessageFixture;
+import dev.handsup.fixture.ChatRoomFixture;
+import dev.handsup.fixture.ProductFixture;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.repository.UserRepository;
+
+class ChatMessageRepositoryTest extends DataJpaTestSupport {
+
+	private User bidder, seller;
+	private ChatRoom chatRoom;
+
+	@Autowired
+	private ChatRoomRepository chatRoomRepository;
+
+	@Autowired
+	private ChatMessageRepository chatMessageRepository;
+
+	@Autowired
+	private BiddingRepository biddingRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private AuctionRepository auctionRepository;
+	@Autowired
+	private ProductCategoryRepository productCategoryRepository;
+
+	@BeforeEach
+	void setUp() {
+		seller = userRepository.save(UserFixture.user("seller@gmail.com"));
+		bidder = userRepository.save(UserFixture.user("buyer@gmail.com"));
+		ProductCategory category = productCategoryRepository.save(ProductFixture.productCategory("디지털 기기"));
+		Auction auction = auctionRepository.save(AuctionFixture.auction(category));
+		Bidding bidding = biddingRepository.save(BiddingFixture.bidding(auction, bidder, TradingStatus.PREPARING));
+
+		chatRoom = chatRoomRepository.save(
+			ChatRoomFixture.chatRoom(auction.getId(), seller, bidder, bidding.getId()));
+	}
+
+	@DisplayName("[수신받은 메시지를 벌크 연산으로 읽음처리할 수 있다.]")
+	@Test
+	void readReceiveMessages() {
+	    //given
+		chatMessageRepository.saveAll(
+			List.of(
+				ChatMessageFixture.chatMessage(chatRoom, seller),
+				ChatMessageFixture.chatMessage(chatRoom, seller)
+			)
+		);
+
+	    //when
+		chatMessageRepository.readReceivedMessages(chatRoom, bidder.getId());
+
+	    //then
+		List<ChatMessage> messages = chatMessageRepository.findAll();
+		assertThat(messages.get(0).getIsRead()).isTrue();
+		assertThat(messages.get(1).getIsRead()).isTrue();
+	}
+}

--- a/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/chat/repository/ChatMessageRepositoryTest.java
@@ -63,7 +63,7 @@ class ChatMessageRepositoryTest extends DataJpaTestSupport {
 	@DisplayName("[수신받은 메시지를 벌크 연산으로 읽음처리할 수 있다.]")
 	@Test
 	void readReceiveMessages() {
-	    //given
+		//given
 		chatMessageRepository.saveAll(
 			List.of(
 				ChatMessageFixture.chatMessage(chatRoom, seller),
@@ -71,10 +71,10 @@ class ChatMessageRepositoryTest extends DataJpaTestSupport {
 			)
 		);
 
-	    //when
+		//when
 		chatMessageRepository.readReceivedMessages(chatRoom, bidder.getId());
 
-	    //then
+		//then
 		List<ChatMessage> messages = chatMessageRepository.findAll();
 		assertThat(messages.get(0).getIsRead()).isTrue();
 		assertThat(messages.get(1).getIsRead()).isTrue();

--- a/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
+++ b/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
@@ -71,7 +71,7 @@ class ChatRoomServiceTest {
 		Bidding bidding = BiddingFixture.bidding(auction, bidder, TradingStatus.PREPARING);
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 
-		given(biddingRepository.findById(anyLong())).willReturn(Optional.of(bidding));
+		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 
 		given(auction.getSeller()).willReturn(seller); //validateAuthorization
 		given(auction.getStatus()).willReturn(AuctionStatus.TRADING);
@@ -94,7 +94,7 @@ class ChatRoomServiceTest {
 		Bidding bidding = BiddingFixture.bidding(auction, bidder, TradingStatus.PREPARING);
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 
-		given(biddingRepository.findById(anyLong())).willReturn(Optional.of(bidding));
+		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 
 		given(auction.getSeller()).willReturn(seller); //validateAuthorization
 		given(auction.getStatus()).willReturn(AuctionStatus.TRADING);
@@ -130,7 +130,7 @@ class ChatRoomServiceTest {
 		Bidding bidding = BiddingFixture.bidding(auction, bidder, TradingStatus.PREPARING);
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 
-		given(biddingRepository.findById(bidding.getId())).willReturn(Optional.of(bidding));
+		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 		given(chatRoomRepository.findById(chatRoom.getId())).willReturn(Optional.of(chatRoom));
 
 		//when
@@ -152,7 +152,7 @@ class ChatRoomServiceTest {
 		Bidding bidding = BiddingFixture.bidding(auction, bidder);
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 
-		given(biddingRepository.findById(bidding.getId())).willReturn(Optional.of(bidding));
+		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 		given(chatRoomRepository.findChatRoomByCurrentBiddingId(bidding.getId()))
 			.willReturn(Optional.of(chatRoom));
 
@@ -181,7 +181,7 @@ class ChatRoomServiceTest {
 			.willReturn(new SliceImpl<>(List.of(chatMessage1, chatMessage2), pageRequest, false));
 
 		//when
-		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(1L, seller, pageRequest);
+		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(1L, pageRequest);
 		//then
 		assertThat(response.content()).hasSize(2);
 	}

--- a/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
+++ b/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
@@ -181,7 +181,7 @@ class ChatRoomServiceTest {
 			.willReturn(new SliceImpl<>(List.of(chatMessage1, chatMessage2), pageRequest, false));
 
 		//when
-		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(1L, pageRequest);
+		PageResponse<ChatMessageResponse> response = chatRoomService.getChatRoomMessages(1L, seller, pageRequest);
 		//then
 		assertThat(response.content()).hasSize(2);
 	}


### PR DESCRIPTION
### 📑 작업 상세 내용

- 채팅방 메시지 조회
 - repository 함수 추가
-  채팅방 조회 시 수신한 메시지 읽음 처리
 - jpql 작성 및 repository 테스트
 - 입찰 아이디로 조회, 채팅방 아이디로 조회에 repository 함수 호출

### 💫 작업 요약

- 채팅방 메시지 조회 API
- 채팅방 메시지 읽음 처리 채팅방 상세 조회 비즈니스 로직에 추가

### 🔍 중점적으로 리뷰 할 부분

- 채팅방 메시지 조회 시 유저 권한도 체크해야 하는지 아니면 채팅방 조회할 때만 호출(여기서 한번 권한 체크)하니까 상관없는지