### PR TITLE
[feat] : 리뷰 등록 API 개선

### DIFF
--- a/api/src/main/java/dev/handsup/review/controller/ReviewApiController.java
+++ b/api/src/main/java/dev/handsup/review/controller/ReviewApiController.java
@@ -12,7 +12,8 @@ import org.springframework.web.bind.annotation.RestController;
 import dev.handsup.auth.jwt.JwtAuthorization;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.review.dto.request.RegisterReviewRequest;
-import dev.handsup.review.dto.response.ReviewResponse;
+import dev.handsup.review.dto.response.ReviewDetailResponse;
+import dev.handsup.review.dto.response.ReviewSimpleResponse;
 import dev.handsup.review.service.ReviewService;
 import dev.handsup.user.domain.User;
 import io.swagger.v3.oas.annotations.Operation;
@@ -32,12 +33,12 @@ public class ReviewApiController {
 	@PostMapping("/{auctionId}/reviews")
 	@Operation(summary = "리뷰 등록 API", description = "리뷰를 등록한다")
 	@ApiResponse(useReturnTypeSchema = true)
-	public ResponseEntity<ReviewResponse> registerReview(
+	public ResponseEntity<ReviewDetailResponse> registerReview(
 		@Valid @RequestBody RegisterReviewRequest request,
 		@PathVariable Long auctionId,
 		@JwtAuthorization User writer
 	) {
-		ReviewResponse response = reviewService.registerReview(
+		ReviewDetailResponse response = reviewService.registerReview(
 			request,
 			auctionId,
 			writer
@@ -48,11 +49,11 @@ public class ReviewApiController {
 	@GetMapping("/{auctionId}/reviews")
 	@Operation(summary = "경매 리뷰 조회 API", description = "해당 경매의 리뷰를 전체 조회한다")
 	@ApiResponse(useReturnTypeSchema = true)
-	public ResponseEntity<PageResponse<ReviewResponse>> getReviewsOfAuction(
+	public ResponseEntity<PageResponse<ReviewSimpleResponse>> getReviewsOfAuction(
 		@PathVariable Long auctionId,
 		Pageable pageable
 	) {
-		PageResponse<ReviewResponse> response = reviewService.getReviewsOfAuction(auctionId, pageable);
+		PageResponse<ReviewSimpleResponse> response = reviewService.getReviewsOfAuction(auctionId, pageable);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
@@ -33,9 +32,9 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 
 	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
+	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	private final User user = UserFixture.user();
 	private final User seller = UserFixture.user("seller@naver.com");
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -30,11 +30,6 @@ import dev.handsup.user.domain.User;
 @DisplayName("[Bookmark 통합 테스트]")
 class BookmarkApiControllerTest extends ApiTestSupport {
 
-	private final String DIGITAL_DEVICE = "디지털 기기";
-	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
-	private final User user = UserFixture.user();
-	private final User seller = UserFixture.user("seller@naver.com");
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired
@@ -43,6 +38,12 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 	private ProductCategoryRepository productCategoryRepository;
 	@Autowired
 	private FCMTokenRepository fcmTokenRepository;
+
+	private final String DIGITAL_DEVICE = "디지털 기기";
+	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
+	private final User user = UserFixture.user();
+	private final User seller = UserFixture.user("seller@naver.com");
+	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 
 	@BeforeEach
 	void setUp() {

--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -43,6 +43,14 @@ import dev.handsup.user.repository.UserRepository;
 @DisplayName("[Review 통합 테스트]")
 class ReviewApiControllerTest extends ApiTestSupport {
 
+	private final Review review = ReviewFixture.review(1L);
+	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
+		1L, ReviewLabelValue.MANNER.getDescription()
+	);
+	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
+		2L, ReviewLabelValue.CHEAP.getDescription()
+	);
+	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 	@Autowired
 	private ReviewRepository reviewRepository;
 	@Autowired
@@ -55,15 +63,6 @@ class ReviewApiControllerTest extends ApiTestSupport {
 	private BiddingService biddingService;
 	@Autowired
 	private UserRepository userRepository;
-
-	private final Review review = ReviewFixture.review(1L);
-	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
-		1L, ReviewLabelValue.MANNER.getDescription()
-	);
-	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
-		2L, ReviewLabelValue.CHEAP.getDescription()
-	);
-	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 	private Auction auction;
 
 	@BeforeEach

--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -6,43 +6,42 @@ import static org.springframework.http.MediaType.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.auction.domain.product.product_category.ProductCategoryValue;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.domain.TradingStatus;
+import dev.handsup.bidding.repository.BiddingRepository;
+import dev.handsup.bidding.service.BiddingService;
 import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.common.support.ApiTestSupport;
 import dev.handsup.fixture.AuctionFixture;
-import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.ReviewFixture;
 import dev.handsup.fixture.ReviewLabelFixture;
 import dev.handsup.review.domain.Review;
 import dev.handsup.review.domain.ReviewLabel;
 import dev.handsup.review.domain.ReviewLabelValue;
 import dev.handsup.review.dto.request.RegisterReviewRequest;
-import dev.handsup.review.dto.response.ReviewResponse;
+import dev.handsup.review.dto.response.ReviewDetailResponse;
 import dev.handsup.review.repository.ReviewLabelRepository;
 import dev.handsup.review.repository.ReviewRepository;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.exception.UserErrorCode;
+import dev.handsup.user.repository.UserRepository;
 
 @DisplayName("[Review 통합 테스트]")
 class ReviewApiControllerTest extends ApiTestSupport {
-
-	private final Review review = ReviewFixture.review();
-	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
-		1L, ReviewLabelValue.MANNER.getDescription()
-	);
-	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
-		2L, ReviewLabelValue.CHEAP.getDescription()
-	);
-	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 
 	@Autowired
 	private ReviewRepository reviewRepository;
@@ -50,35 +49,65 @@ class ReviewApiControllerTest extends ApiTestSupport {
 	private ReviewLabelRepository reviewLabelRepository;
 	@Autowired
 	private ProductCategoryRepository productCategoryRepository;
-	private ProductCategory productCategory;
+	@Autowired
+	private BiddingRepository biddingRepository;
+	@Autowired
+	private BiddingService biddingService;
+	@Autowired
+	private UserRepository userRepository;
+
+	private final Review review = ReviewFixture.review(1L);
+	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
+		1L, ReviewLabelValue.MANNER.getDescription()
+	);
+	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
+		2L, ReviewLabelValue.CHEAP.getDescription()
+	);
+	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 	private Auction auction;
 
 	@BeforeEach
 	void setUp() {
-		String DIGITAL_DEVICE = "디지털 기기";
-		productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
-		productCategoryRepository.save(productCategory);
-		auction = auctionRepository.save(AuctionFixture.auction(productCategory));
+		productCategoryRepository.save(review.getAuction().getProduct().getProductCategory());
+		auction = auctionRepository.save(review.getAuction());
 		reviewLabelRepository.saveAll(List.of(reviewLabelManner, reviewLabelCheap));
 	}
 
 	@Test
+	@Transactional
 	@DisplayName("[리뷰 등록 API] 작성자가 경매에 대한 리뷰를 등록한다")
 	void registerReviewTest() throws Exception {
 		// given
-		Long auctionId = 1L;
+		Long auctionId = review.getAuction().getId();
+		int beforeSellerScore = auction.getSeller().getScore();
+		LocalDateTime now = LocalDateTime.now();
+		ReflectionTestUtils.setField(review, "createdAt", now);
+
+		Bidding bidding = new Bidding(
+			auction.getInitPrice() + 1000, auction, user, TradingStatus.PROGRESSING);
+		biddingRepository.save(bidding);
+		biddingService.completeTrading(bidding.getId(), user);
+
 		RegisterReviewRequest request = RegisterReviewRequest.of(
 			review.getEvaluationScore(),
 			review.getContent(),
 			reviewLabelIds
 		);
-		ReviewResponse expectedResponse = ReviewResponse.of(
+
+		ReviewDetailResponse expectedResponse = ReviewDetailResponse.of(
+			review.getId(),
 			review.getEvaluationScore(),
 			review.getContent(),
 			auctionId,
-			user.getId()
+			user.getId(),
+			user.getNickname(),
+			auction.getTitle(),
+			bidding.getBiddingPrice(),
+			auction.getTradeMethod().toString(),
+			auction.getTradingLocation(),
+			bidding.getTradingCreatedAt().toString(),
+			review.getCreatedAt().toString()
 		);
-		int beforeSellerScore = auction.getSeller().getScore();
 
 		// when & then
 		mockMvc.perform(post("/api/auctions/{auctionId}/reviews", auctionId)
@@ -86,10 +115,19 @@ class ReviewApiControllerTest extends ApiTestSupport {
 				.contentType(APPLICATION_JSON)
 				.content(toJson(request)))
 			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.reviewId").value(expectedResponse.reviewId()))
 			.andExpect(jsonPath("$.evaluationScore").value(expectedResponse.evaluationScore()))
 			.andExpect(jsonPath("$.content").value(expectedResponse.content()))
 			.andExpect(jsonPath("$.auctionId").value(expectedResponse.auctionId()))
-			.andExpect(jsonPath("$.writerId").value(expectedResponse.writerId()));
+			.andExpect(jsonPath("$.writerId").value(expectedResponse.writerId()))
+			.andExpect(jsonPath("$.writerNickname").value(expectedResponse.writerNickname()))
+			.andExpect(jsonPath("$.auctionTitle").value(expectedResponse.auctionTitle()))
+			.andExpect(jsonPath("$.winningPrice").value(expectedResponse.winningPrice()))
+			.andExpect(jsonPath("$.tradeMethod").value(expectedResponse.tradeMethod()))
+			.andExpect(jsonPath("$.tradingLocation.si").value(expectedResponse.tradingLocation().getSi()))
+			.andExpect(jsonPath("$.tradingLocation.gu").value(expectedResponse.tradingLocation().getGu()))
+			.andExpect(jsonPath("$.tradingLocation.dong").value(expectedResponse.tradingLocation().getDong()))
+			.andExpect(jsonPath("$.tradingCreatedAt").value(expectedResponse.tradingCreatedAt()));
 
 		User evaluatedSeller = userRepository.findById(auction.getSeller().getId())
 			.orElseThrow(() -> new NotFoundException(UserErrorCode.NOT_FOUND_USER));
@@ -103,7 +141,9 @@ class ReviewApiControllerTest extends ApiTestSupport {
 	void getReviewsOfAuctionTest() throws Exception {
 		// given
 		Auction auction1 = auction;
-		Auction auction2 = AuctionFixture.auction(productCategory);
+		ProductCategory productCategoryBooks = ProductCategory.from(ProductCategoryValue.BOOKS.toString());
+		productCategoryRepository.save(productCategoryBooks);
+		Auction auction2 = AuctionFixture.auction(productCategoryBooks);
 		auctionRepository.save(auction2);
 
 		Review review1 = ReviewFixture.review("content1", auction1);

--- a/core/src/main/java/dev/handsup/auction/domain/auction_field/TradingLocation.java
+++ b/core/src/main/java/dev/handsup/auction/domain/auction_field/TradingLocation.java
@@ -22,8 +22,8 @@ public class TradingLocation {
 	@Column(name = "dong")
 	private String dong;
 
-	@Builder(access = PRIVATE)
-	public TradingLocation(String si, String gu, String dong) {
+	@Builder
+	private TradingLocation(String si, String gu, String dong) {
 		this.si = si;
 		this.gu = gu;
 		this.dong = dong;

--- a/core/src/main/java/dev/handsup/auction/domain/auction_field/TradingLocation.java
+++ b/core/src/main/java/dev/handsup/auction/domain/auction_field/TradingLocation.java
@@ -12,7 +12,6 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 public class TradingLocation {
-	private static final String TRADING_LOCATION = "TradingLocation";
 
 	@Column(name = "si")
 	private String si;

--- a/core/src/main/java/dev/handsup/bidding/domain/Bidding.java
+++ b/core/src/main/java/dev/handsup/bidding/domain/Bidding.java
@@ -6,6 +6,8 @@ import static jakarta.persistence.FetchType.*;
 import static jakarta.persistence.GenerationType.*;
 import static lombok.AccessLevel.*;
 
+import java.time.LocalDateTime;
+
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.bidding.exception.BiddingErrorCode;
 import dev.handsup.common.entity.TimeBaseEntity;
@@ -52,6 +54,9 @@ public class Bidding extends TimeBaseEntity {
 	@Column(name = "trading_status", nullable = false)
 	private TradingStatus tradingStatus;
 
+	@Column(name = "trading_created_at")
+	private LocalDateTime tradingCreatedAt;
+
 	@Builder
 	private Bidding(int biddingPrice, Auction auction, User bidder) {
 		this.biddingPrice = biddingPrice;
@@ -60,8 +65,8 @@ public class Bidding extends TimeBaseEntity {
 		this.tradingStatus = TradingStatus.WAITING;
 	}
 
-	//테스트용
-	private Bidding(Long id, int biddingPrice, Auction auction, User bidder, TradingStatus tradingStatus) {
+	// 테스트용
+	public Bidding(Long id, int biddingPrice, Auction auction, User bidder, TradingStatus tradingStatus) {
 		this.id = id;
 		this.biddingPrice = biddingPrice;
 		this.auction = auction;
@@ -69,7 +74,8 @@ public class Bidding extends TimeBaseEntity {
 		this.tradingStatus = tradingStatus;
 	}
 
-	private Bidding(int biddingPrice, Auction auction, User bidder, TradingStatus tradingStatus) {
+	// 테스트용
+	public Bidding(int biddingPrice, Auction auction, User bidder, TradingStatus tradingStatus) {
 		this.biddingPrice = biddingPrice;
 		this.auction = auction;
 		this.bidder = bidder;
@@ -82,14 +88,6 @@ public class Bidding extends TimeBaseEntity {
 			.auction(auction)
 			.bidder(bidder)
 			.build();
-	}
-
-	public static Bidding of(Long id, int biddingPrice, Auction auction, User bidder, TradingStatus status) {
-		return new Bidding(id, biddingPrice, auction, bidder, status);
-	}
-
-	public static Bidding of(int biddingPrice, Auction auction, User bidder, TradingStatus status) {
-		return new Bidding(biddingPrice, auction, bidder, status);
 	}
 
 	// 비즈니스 메서드
@@ -119,5 +117,9 @@ public class Bidding extends TimeBaseEntity {
 			throw new ValidationException(BiddingErrorCode.CAN_NOT_PROGRESS_TRADING);
 		}
 		tradingStatus = TradingStatus.PROGRESSING;
+	}
+
+	public void updateTradingCreatedAt(LocalDateTime tradingCreatedAt) {
+		this.tradingCreatedAt = tradingCreatedAt;
 	}
 }

--- a/core/src/main/java/dev/handsup/bidding/domain/Bidding.java
+++ b/core/src/main/java/dev/handsup/bidding/domain/Bidding.java
@@ -54,9 +54,6 @@ public class Bidding extends TimeBaseEntity {
 	@Column(name = "trading_status", nullable = false)
 	private TradingStatus tradingStatus;
 
-	@Column(name = "trading_created_at")
-	private LocalDateTime tradingCreatedAt;
-
 	@Builder
 	private Bidding(int biddingPrice, Auction auction, User bidder) {
 		this.biddingPrice = biddingPrice;
@@ -117,9 +114,5 @@ public class Bidding extends TimeBaseEntity {
 			throw new ValidationException(BiddingErrorCode.CAN_NOT_PROGRESS_TRADING);
 		}
 		tradingStatus = TradingStatus.PROGRESSING;
-	}
-
-	public void updateTradingCreatedAt(LocalDateTime tradingCreatedAt) {
-		this.tradingCreatedAt = tradingCreatedAt;
 	}
 }

--- a/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
@@ -25,20 +25,6 @@ public class BiddingMapper {
 		);
 	}
 
-	public static BiddingResponse toBiddingResponse(Bidding bidding, String tradingCompletedAt) {
-		return BiddingResponse.of(
-			bidding.getId(),
-			bidding.getBiddingPrice(),
-			bidding.getAuction().getId(),
-			bidding.getBidder().getId(),
-			bidding.getBidder().getNickname(),
-			bidding.getTradingStatus().getLabel(),
-			bidding.getBidder().getProfileImageUrl(),
-			bidding.getCreatedAt().toString(),
-			tradingCompletedAt
-		);
-	}
-
 	public static Bidding toBidding(RegisterBiddingRequest request, Auction auction, User bidder) {
 		return Bidding.of(
 			request.biddingPrice(),
@@ -46,4 +32,5 @@ public class BiddingMapper {
 			bidder
 		);
 	}
+
 }

--- a/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/BiddingMapper.java
@@ -25,6 +25,20 @@ public class BiddingMapper {
 		);
 	}
 
+	public static BiddingResponse toBiddingResponse(Bidding bidding, String tradingCompletedAt) {
+		return BiddingResponse.of(
+			bidding.getId(),
+			bidding.getBiddingPrice(),
+			bidding.getAuction().getId(),
+			bidding.getBidder().getId(),
+			bidding.getBidder().getNickname(),
+			bidding.getTradingStatus().getLabel(),
+			bidding.getBidder().getProfileImageUrl(),
+			bidding.getCreatedAt().toString(),
+			tradingCompletedAt
+		);
+	}
+
 	public static Bidding toBidding(RegisterBiddingRequest request, Auction auction, User bidder) {
 		return Bidding.of(
 			request.biddingPrice(),

--- a/core/src/main/java/dev/handsup/bidding/dto/response/BiddingResponse.java
+++ b/core/src/main/java/dev/handsup/bidding/dto/response/BiddingResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 
 @Builder(access = PRIVATE)
 public record BiddingResponse(
+
 	Long biddingId,
 	int biddingPrice,
 	Long auctionId,
@@ -13,7 +14,8 @@ public record BiddingResponse(
 	String bidderNickname,
 	String tradingStatus,
 	String imgUrl,
-	String createdAt
+	String createdAt,
+	String tradingCompletedAt
 ) {
 	public static BiddingResponse of(
 		Long biddingId,
@@ -34,6 +36,31 @@ public record BiddingResponse(
 			.tradingStatus(tradingStatus)
 			.imgUrl(imgUrl)
 			.createdAt(createdAt)
+			.tradingCompletedAt(null)
+			.build();
+	}
+
+	public static BiddingResponse of(
+		Long biddingId,
+		int biddingPrice,
+		Long auctionId,
+		Long bidderId,
+		String bidderNickname,
+		String tradingStatus,
+		String imgUrl,
+		String createdAt,
+		String tradingCompletedAt
+	) {
+		return BiddingResponse.builder()
+			.biddingId(biddingId)
+			.biddingPrice(biddingPrice)
+			.auctionId(auctionId)
+			.bidderId(bidderId)
+			.bidderNickname(bidderNickname)
+			.tradingStatus(tradingStatus)
+			.imgUrl(imgUrl)
+			.createdAt(createdAt)
+			.tradingCompletedAt(tradingCompletedAt)
 			.build();
 	}
 }

--- a/core/src/main/java/dev/handsup/bidding/exception/BiddingErrorCode.java
+++ b/core/src/main/java/dev/handsup/bidding/exception/BiddingErrorCode.java
@@ -15,7 +15,9 @@ public enum BiddingErrorCode implements ErrorCode {
 	CAN_NOT_PREPARE_TRADING("거래를 준비할 수 없는 상태입니다.", "B_005"),
 
 	CAN_NOT_PROGRESS_TRADING("거래를 진행할 수 없는 상태입니다.", "B_006"),
-	NOT_AUTHORIZED_SELLER("거래 상태를 판매자만 변경 가능합니다.", "B_007");
+	NOT_AUTHORIZED_SELLER("거래 상태를 판매자만 변경 가능합니다.", "B_007"),
+	NOT_FOUND_BIDDING_BY_AUCTION_AND_BIDDER(
+		"경매 아이디와 입찰자 아이디에 해당하는 입찰이 존재하지 않습니다.", "B_008");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -7,8 +7,10 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
+import dev.handsup.auction.domain.Auction;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
+import dev.handsup.user.domain.User;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
@@ -18,4 +20,6 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 	Slice<Bidding> findByAuctionIdOrderByBiddingPriceDesc(Long auctionId, Pageable pageable);
 
 	Optional<Bidding> findFirstByTradingStatus(TradingStatus tradingStatus);
+
+	Optional<Bidding> findByAuctionAndBidder(Auction auction, User bidder);
 }

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -1,5 +1,7 @@
 package dev.handsup.bidding.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.bidding.domain.Bidding;
-import dev.handsup.bidding.domain.TradingStatus;
 import dev.handsup.user.domain.User;
 
 public interface BiddingRepository extends JpaRepository<Bidding, Long> {
@@ -23,8 +24,6 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 	Integer findMaxBiddingPriceByAuctionId(Long auctionId);
 
 	Slice<Bidding> findByAuctionIdOrderByBiddingPriceDesc(Long auctionId, Pageable pageable);
-
-	Optional<Bidding> findFirstByTradingStatus(TradingStatus tradingStatus);
 
 	Optional<Bidding> findByAuctionAndBidder(Auction auction, User bidder);
 }

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -1,6 +1,5 @@
 package dev.handsup.bidding.service;
 
-import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.data.domain.Pageable;
@@ -78,20 +77,17 @@ public class BiddingService {
 
 	@Transactional
 	public BiddingResponse completeTrading(Long biddingId, User seller) {
-		LocalDateTime now = LocalDateTime.now();
-
 		Bidding bidding = findBiddingById(biddingId);
 		validateAuthorization(bidding, seller);
 
 		bidding.updateTradingStatusComplete();
 		bidding.getAuction().updateBuyer(bidding.getBidder());
-		bidding.updateTradingCreatedAt(now);
 
 		// 거래 완료 알림 추가
 		bidding.getAuction().changeAuctionStatusCompleted();
 		//
 
-		return BiddingMapper.toBiddingResponse(bidding, now.toString());
+		return BiddingMapper.toBiddingResponse(bidding);
 	}
 
 	@Transactional

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -1,5 +1,6 @@
 package dev.handsup.bidding.service;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 import org.springframework.data.domain.Pageable;
@@ -74,14 +75,18 @@ public class BiddingService {
 
 	@Transactional
 	public BiddingResponse completeTrading(Long biddingId, User seller) {
+		LocalDateTime now = LocalDateTime.now();
+
 		Bidding bidding = findBiddingById(biddingId);
 		validateAuthorization(bidding, seller);
+
 		bidding.updateTradingStatusComplete();
 		bidding.getAuction().updateBuyer(bidding.getBidder());
+		bidding.updateTradingCreatedAt(now);
 
-		//
+		// 거래 완료 알림 추가
 
-		return BiddingMapper.toBiddingResponse(bidding);
+		return BiddingMapper.toBiddingResponse(bidding, now.toString());
 	}
 
 	@Transactional
@@ -100,7 +105,7 @@ public class BiddingService {
 		}
 	}
 
-	private Bidding findBiddingById(Long biddingId) {
+	public Bidding findBiddingById(Long biddingId) {
 		return biddingRepository.findById(biddingId)
 			.orElseThrow(() -> new NotFoundException(BiddingErrorCode.NOT_FOUND_BIDDING));
 	}

--- a/core/src/main/java/dev/handsup/notification/domain/NotificationType.java
+++ b/core/src/main/java/dev/handsup/notification/domain/NotificationType.java
@@ -8,10 +8,11 @@ import lombok.RequiredArgsConstructor;
 public enum NotificationType {
 
 	CHAT("채팅 알림", "님이 회원님과의 채팅방에서 속삭이고 있어요."),
-	COMMENT("댓글 알림", "님이 회원님의 경매 물품에서 얘기하고 있어요."),
-	BOOKMARK("북마크 알림", "님이 회원님의 경매 물품을 관심있어 해요."),
+	COMMENT("자신의 경매의 댓글 알림 알림", "님이 회원님의 경매 물품에서 얘기하고 있어요."),
+	BOOKMARK("자신의 경매의 북마크 알림", "님이 회원님의 경매 물품을 관심있어 해요."),
 	PURCHASE_WINNING("구매 입찰의 낙찰 알림", "입찰하신 물품이 낙찰되었습니다."),
-	CANCELED_PURCHASE_WINNING("구매 입찰의 낙찰 취소 알림", "경매 낙찰이 취소되었습니다.");
+	CANCELED_PURCHASE_TRADING("구매 입찰의 거래 취소 알림", "거래가 취소되었습니다."),
+	COMPLETED_PURCHASE_TRADING("구매 입찰의 거래 완료 알림", "거래가 완료되었습니다.");
 
 	private final String title;
 	private final String content;

--- a/core/src/main/java/dev/handsup/notification/service/FCMService.java
+++ b/core/src/main/java/dev/handsup/notification/service/FCMService.java
@@ -35,7 +35,7 @@ public class FCMService {
 			throw new NotificationException(NotificationErrorCode.NOT_FOUND_FCM_TOKEN);
 		}
 
-		if (notificationType.equals(NotificationType.CANCELED_PURCHASE_WINNING) ||
+		if (notificationType.equals(NotificationType.CANCELED_PURCHASE_TRADING) ||
 			notificationType.equals(NotificationType.PURCHASE_WINNING)) {
 			senderNickname = "";
 		}

--- a/core/src/main/java/dev/handsup/review/dto/ReviewMapper.java
+++ b/core/src/main/java/dev/handsup/review/dto/ReviewMapper.java
@@ -5,7 +5,7 @@ import static lombok.AccessLevel.*;
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.review.domain.Review;
 import dev.handsup.review.dto.request.RegisterReviewRequest;
-import dev.handsup.review.dto.response.ReviewResponse;
+import dev.handsup.review.dto.response.ReviewSimpleResponse;
 import dev.handsup.user.domain.User;
 import lombok.NoArgsConstructor;
 
@@ -25,12 +25,15 @@ public class ReviewMapper {
 		);
 	}
 
-	public static ReviewResponse toReviewResponse(Review review) {
-		return ReviewResponse.of(
+	public static ReviewSimpleResponse toReviewSimpleResponse(Review review) {
+		return ReviewSimpleResponse.of(
+			review.getId(),
 			review.getEvaluationScore(),
 			review.getContent(),
 			review.getAuction().getId(),
-			review.getWriter().getId()
+			review.getWriter().getId(),
+			review.getWriter().getNickname(),
+			review.getCreatedAt().toString()
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/review/dto/ReviewMapper.java
+++ b/core/src/main/java/dev/handsup/review/dto/ReviewMapper.java
@@ -3,8 +3,10 @@ package dev.handsup.review.dto;
 import static lombok.AccessLevel.*;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.review.domain.Review;
 import dev.handsup.review.dto.request.RegisterReviewRequest;
+import dev.handsup.review.dto.response.ReviewDetailResponse;
 import dev.handsup.review.dto.response.ReviewSimpleResponse;
 import dev.handsup.user.domain.User;
 import lombok.NoArgsConstructor;
@@ -33,6 +35,24 @@ public class ReviewMapper {
 			review.getAuction().getId(),
 			review.getWriter().getId(),
 			review.getWriter().getNickname(),
+			review.getCreatedAt().toString()
+		);
+	}
+
+	public static ReviewDetailResponse toReviewDetailResponse(
+		Review review, Auction auction, Bidding bidding) {
+		return ReviewDetailResponse.of(
+			review.getId(),
+			review.getEvaluationScore(),
+			review.getContent(),
+			auction.getId(),
+			review.getWriter().getId(),
+			review.getWriter().getNickname(),
+			auction.getTitle(),
+			bidding.getBiddingPrice(),
+			auction.getTradeMethod().toString(),
+			auction.getTradingLocation(),
+			bidding.getUpdatedAt().toString(),
 			review.getCreatedAt().toString()
 		);
 	}

--- a/core/src/main/java/dev/handsup/review/dto/response/ReviewDetailResponse.java
+++ b/core/src/main/java/dev/handsup/review/dto/response/ReviewDetailResponse.java
@@ -1,0 +1,48 @@
+package dev.handsup.review.dto.response;
+
+import static lombok.AccessLevel.*;
+
+import dev.handsup.auction.domain.auction_field.TradeMethod;
+import dev.handsup.auction.domain.auction_field.TradingLocation;
+import lombok.Builder;
+
+@Builder(access = PRIVATE)
+public record ReviewDetailResponse(
+
+	int evaluationScore,
+	String content,
+	Long auctionId,
+	Long writerId,
+	String auctionTitle,
+	int winningPrice,
+	TradeMethod tradeMethod,
+	TradingLocation tradingLocation,
+	String tradingCreatedAt,
+	String reviewCreatedAt
+) {
+	public static ReviewDetailResponse of(
+		int evaluationScore,
+		String content,
+		Long auctionId,
+		Long writerId,
+		String auctionTitle,
+		int winningPrice,
+		TradeMethod tradeMethod,
+		TradingLocation tradingLocation,
+		String tradingCreatedAt,
+		String reviewCreatedAt
+	) {
+		return ReviewDetailResponse.builder()
+			.evaluationScore(evaluationScore)
+			.content(content)
+			.auctionId(auctionId)
+			.writerId(writerId)
+			.auctionTitle(auctionTitle)
+			.winningPrice(winningPrice)
+			.tradeMethod(tradeMethod)
+			.tradingLocation(tradingLocation)
+			.tradingCreatedAt(tradingCreatedAt)
+			.reviewCreatedAt(reviewCreatedAt)
+			.build();
+	}
+}

--- a/core/src/main/java/dev/handsup/review/dto/response/ReviewDetailResponse.java
+++ b/core/src/main/java/dev/handsup/review/dto/response/ReviewDetailResponse.java
@@ -2,41 +2,46 @@ package dev.handsup.review.dto.response;
 
 import static lombok.AccessLevel.*;
 
-import dev.handsup.auction.domain.auction_field.TradeMethod;
 import dev.handsup.auction.domain.auction_field.TradingLocation;
 import lombok.Builder;
 
 @Builder(access = PRIVATE)
 public record ReviewDetailResponse(
 
+	Long reviewId,
 	int evaluationScore,
 	String content,
 	Long auctionId,
 	Long writerId,
+	String writerNickname,
 	String auctionTitle,
 	int winningPrice,
-	TradeMethod tradeMethod,
+	String tradeMethod,
 	TradingLocation tradingLocation,
 	String tradingCreatedAt,
 	String reviewCreatedAt
 ) {
 	public static ReviewDetailResponse of(
+		Long reviewId,
 		int evaluationScore,
 		String content,
 		Long auctionId,
 		Long writerId,
+		String writerNickname,
 		String auctionTitle,
 		int winningPrice,
-		TradeMethod tradeMethod,
+		String tradeMethod,
 		TradingLocation tradingLocation,
 		String tradingCreatedAt,
 		String reviewCreatedAt
 	) {
 		return ReviewDetailResponse.builder()
+			.reviewId(reviewId)
 			.evaluationScore(evaluationScore)
 			.content(content)
 			.auctionId(auctionId)
 			.writerId(writerId)
+			.writerNickname(writerNickname)
 			.auctionTitle(auctionTitle)
 			.winningPrice(winningPrice)
 			.tradeMethod(tradeMethod)

--- a/core/src/main/java/dev/handsup/review/dto/response/ReviewSimpleResponse.java
+++ b/core/src/main/java/dev/handsup/review/dto/response/ReviewSimpleResponse.java
@@ -5,24 +5,33 @@ import static lombok.AccessLevel.*;
 import lombok.Builder;
 
 @Builder(access = PRIVATE)
-public record ReviewResponse(
+public record ReviewSimpleResponse(
 
+	Long reviewId,
 	int evaluationScore,
 	String content,
 	Long auctionId,
-	Long writerId
+	Long writerId,
+	String writerNickName,
+	String reviewCreatedAt
 ) {
-	public static ReviewResponse of(
+	public static ReviewSimpleResponse of(
+		Long reviewId,
 		int evaluationScore,
 		String content,
 		Long auctionId,
-		Long writerId
+		Long writerId,
+		String writerNickName,
+		String reviewCreatedAt
 	) {
-		return ReviewResponse.builder()
+		return ReviewSimpleResponse.builder()
+			.reviewId(reviewId)
 			.evaluationScore(evaluationScore)
 			.content(content)
 			.auctionId(auctionId)
 			.writerId(writerId)
+			.writerNickName(writerNickName)
+			.reviewCreatedAt(reviewCreatedAt)
 			.build();
 	}
 }

--- a/core/src/main/java/dev/handsup/review/service/ReviewService.java
+++ b/core/src/main/java/dev/handsup/review/service/ReviewService.java
@@ -76,9 +76,9 @@ public class ReviewService {
 			review.getWriter().getNickname(),
 			auction.getTitle(),
 			bidding.getBiddingPrice(),
-			auction.getTradeMethod(),
+			auction.getTradeMethod().toString(),
 			auction.getTradingLocation(),
-			"tradingCreateAt",
+			bidding.getTradingCreatedAt().toString(),
 			review.getCreatedAt().toString()
 		);
 	}

--- a/core/src/main/java/dev/handsup/review/service/ReviewService.java
+++ b/core/src/main/java/dev/handsup/review/service/ReviewService.java
@@ -8,6 +8,9 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.exception.AuctionErrorCode;
 import dev.handsup.auction.repository.auction.AuctionRepository;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.exception.BiddingErrorCode;
+import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.common.dto.CommonMapper;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.common.exception.NotFoundException;
@@ -17,7 +20,8 @@ import dev.handsup.review.domain.ReviewLabel;
 import dev.handsup.review.domain.UserReviewLabel;
 import dev.handsup.review.dto.ReviewMapper;
 import dev.handsup.review.dto.request.RegisterReviewRequest;
-import dev.handsup.review.dto.response.ReviewResponse;
+import dev.handsup.review.dto.response.ReviewDetailResponse;
+import dev.handsup.review.dto.response.ReviewSimpleResponse;
 import dev.handsup.review.exception.ReviewErrorCode;
 import dev.handsup.review.repository.ReviewInterReviewLabelRepository;
 import dev.handsup.review.repository.ReviewLabelRepository;
@@ -35,18 +39,18 @@ public class ReviewService {
 	private final ReviewInterReviewLabelRepository reviewInterReviewLabelRepository;
 	private final UserReviewLabelRepository userReviewLabelRepository;
 	private final AuctionRepository auctionRepository;
+	private final BiddingRepository biddingRepository;
 
 	@Transactional
-	public ReviewResponse registerReview(
+	public ReviewDetailResponse registerReview(
 		RegisterReviewRequest request,
 		Long auctionId,
 		User writer
 	) {
 		Auction auction = getAuctionById(auctionId);
 		User seller = auction.getSeller();
-		Review review = reviewRepository.save(
-			ReviewMapper.toReview(request, auction, writer)
-		);
+		Review review = reviewRepository.save(ReviewMapper.toReview(request, auction, writer));
+
 		request.reviewLabelIds().forEach(reviewLabelId -> {
 			ReviewLabel reviewLabel = getReviewById(reviewLabelId);
 			reviewInterReviewLabelRepository.save(
@@ -61,7 +65,22 @@ public class ReviewService {
 
 		seller.operateScore(request.evaluationScore());
 
-		return ReviewMapper.toReviewResponse(review);
+		Bidding bidding = getBidding(auction, writer);
+
+		return ReviewDetailResponse.of(
+			review.getId(),
+			review.getEvaluationScore(),
+			review.getContent(),
+			auction.getId(),
+			review.getWriter().getId(),
+			review.getWriter().getNickname(),
+			auction.getTitle(),
+			bidding.getBiddingPrice(),
+			auction.getTradeMethod(),
+			auction.getTradingLocation(),
+			"tradingCreateAt",
+			review.getCreatedAt().toString()
+		);
 	}
 
 	private ReviewLabel getReviewById(Long reviewLabelId) {
@@ -75,10 +94,15 @@ public class ReviewService {
 	}
 
 	@Transactional(readOnly = true)
-	public PageResponse<ReviewResponse> getReviewsOfAuction(Long auctionId, Pageable pageable) {
-		Slice<ReviewResponse> reviewResponsePage = reviewRepository
+	public PageResponse<ReviewSimpleResponse> getReviewsOfAuction(Long auctionId, Pageable pageable) {
+		Slice<ReviewSimpleResponse> reviewResponsePage = reviewRepository
 			.findByAuctionIdOrderByCreatedAtDesc(auctionId, pageable)
-			.map(ReviewMapper::toReviewResponse);
+			.map(ReviewMapper::toReviewSimpleResponse);
 		return CommonMapper.toPageResponse(reviewResponsePage);
+	}
+
+	private Bidding getBidding(Auction auction, User bidder) {
+		return biddingRepository.findByAuctionAndBidder(auction, bidder)
+			.orElseThrow(() -> new NotFoundException(BiddingErrorCode.NOT_FOUND_BIDDING_BY_AUCTION_AND_BIDDER));
 	}
 }

--- a/core/src/main/java/dev/handsup/review/service/ReviewService.java
+++ b/core/src/main/java/dev/handsup/review/service/ReviewService.java
@@ -48,6 +48,7 @@ public class ReviewService {
 		User writer
 	) {
 		Auction auction = getAuctionById(auctionId);
+		Bidding bidding = getBidding(auction, writer);
 		User seller = auction.getSeller();
 		Review review = reviewRepository.save(ReviewMapper.toReview(request, auction, writer));
 
@@ -65,22 +66,7 @@ public class ReviewService {
 
 		seller.operateScore(request.evaluationScore());
 
-		Bidding bidding = getBidding(auction, writer);
-
-		return ReviewDetailResponse.of(
-			review.getId(),
-			review.getEvaluationScore(),
-			review.getContent(),
-			auction.getId(),
-			review.getWriter().getId(),
-			review.getWriter().getNickname(),
-			auction.getTitle(),
-			bidding.getBiddingPrice(),
-			auction.getTradeMethod().toString(),
-			auction.getTradingLocation(),
-			bidding.getTradingCreatedAt().toString(),
-			review.getCreatedAt().toString()
-		);
+		return ReviewMapper.toReviewDetailResponse(review, auction, bidding);
 	}
 
 	private ReviewLabel getReviewById(Long reviewLabelId) {

--- a/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
+++ b/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.repository.auction.AuctionRepository;
+import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.BiddingFixture;
@@ -104,8 +105,10 @@ class ReviewServiceTest {
 		given(userReviewLabelRepository.findById(userReviewLabelCheap.getId())).willReturn(
 			Optional.of(userReviewLabelCheap));
 
+		Bidding bidding = BiddingFixture.bidding(auction, writer);
+		ReflectionTestUtils.setField(bidding, "tradingCreatedAt", LocalDateTime.now());
 		given(biddingRepository.findByAuctionAndBidder(auction, writer)).willReturn(
-			Optional.of(BiddingFixture.bidding(auction, writer)));
+			Optional.of(bidding));
 
 		// when
 		ReviewDetailResponse response = reviewService.registerReview(request, auctionId, writer);

--- a/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
+++ b/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
@@ -106,7 +106,7 @@ class ReviewServiceTest {
 			Optional.of(userReviewLabelCheap));
 
 		Bidding bidding = BiddingFixture.bidding(auction, writer);
-		ReflectionTestUtils.setField(bidding, "tradingCreatedAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(bidding, "updatedAt", LocalDateTime.now());
 		given(biddingRepository.findByAuctionAndBidder(auction, writer)).willReturn(
 			Optional.of(bidding));
 

--- a/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
+++ b/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
@@ -42,21 +42,6 @@ import dev.handsup.user.repository.UserReviewLabelRepository;
 @DisplayName("[ReviewService 테스트]")
 class ReviewServiceTest {
 
-	@Mock
-	private ReviewRepository reviewRepository;
-	@Mock
-	private ReviewLabelRepository reviewLabelRepository;
-	@Mock
-	private ReviewInterReviewLabelRepository reviewInterReviewLabelRepository;
-	@Mock
-	private UserReviewLabelRepository userReviewLabelRepository;
-	@Mock
-	private AuctionRepository auctionRepository;
-	@Mock
-	private BiddingRepository biddingRepository;
-	@InjectMocks
-	private ReviewService reviewService;
-
 	private final Auction auction = AuctionFixture.auction();
 	private final User writer = UserFixture.user();
 	private final Review review = ReviewFixture.review();
@@ -73,6 +58,20 @@ class ReviewServiceTest {
 	private final UserReviewLabel userReviewLabelCheap = UserReviewLabelFixture.userReviewLabel(
 		2L, reviewLabelCheap
 	);
+	@Mock
+	private ReviewRepository reviewRepository;
+	@Mock
+	private ReviewLabelRepository reviewLabelRepository;
+	@Mock
+	private ReviewInterReviewLabelRepository reviewInterReviewLabelRepository;
+	@Mock
+	private UserReviewLabelRepository userReviewLabelRepository;
+	@Mock
+	private AuctionRepository auctionRepository;
+	@Mock
+	private BiddingRepository biddingRepository;
+	@InjectMocks
+	private ReviewService reviewService;
 
 	@Test
 	@MockitoSettings(strictness = Strictness.LENIENT)

--- a/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
@@ -12,7 +12,7 @@ import lombok.NoArgsConstructor;
 public class BiddingFixture {
 
 	public static Bidding bidding(Auction auction, User user) {
-		return Bidding.of(
+		return new Bidding(
 			1L,
 			40000,
 			auction,
@@ -22,7 +22,7 @@ public class BiddingFixture {
 	}
 
 	public static Bidding bidding(Auction auction, User user, TradingStatus status) {
-		return Bidding.of(
+		return new Bidding(
 			1L,
 			40000,
 			auction,
@@ -32,7 +32,7 @@ public class BiddingFixture {
 	}
 
 	public static Bidding bidding(Auction auction, User user, TradingStatus status, int biddingPrice) {
-		return Bidding.of(
+		return new Bidding(
 			1L,
 			biddingPrice,
 			auction,
@@ -42,7 +42,7 @@ public class BiddingFixture {
 	}
 
 	public static Bidding bidding(User user, Auction auction, TradingStatus status) {
-		return Bidding.of(
+		return new Bidding(
 			40000,
 			auction,
 			user,

--- a/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
@@ -51,7 +51,7 @@ public class BiddingFixture {
 	}
 
 	public static Bidding bidding(User user, Auction auction, TradingStatus status, int price) {
-		return Bidding.of(
+		return new Bidding(
 			price,
 			auction,
 			user,

--- a/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
@@ -19,6 +19,10 @@ public final class ReviewFixture {
 		return Review.of(EVALUATION_SCORE, CONTENT, AUCTION, WRITER);
 	}
 
+	public static Review review(Long reviewId) {
+		return new Review(reviewId, EVALUATION_SCORE, CONTENT, AUCTION, WRITER);
+	}
+
 	public static Review review(String content, Auction auction) {
 		return Review.of(EVALUATION_SCORE, content, auction, WRITER);
 	}


### PR DESCRIPTION
close #98 

### 📑 작업 상세 내용

- ReviewResponse 분리
  - ReviewSimpleResponse : 단순 리뷰 조회용
  - ReviewDetailResponse   : 리뷰 작성 후 영수증 발급용
- 리뷰 등록 후, 거래 영수증을 발급하기 위하여 `ReviewDetailResponse` 에 필드가 여러개 추가되었습니다.

> 특히 `거래 완료 시간`을 응답에 포함하기 위한 로직이 다수 추가되었습니다.
>
> 거래 완료 시간을 포함하기 위해 Bidding 엔티티에 `tradingCreatedAt` 필드를 추가하고, 
> RegisterBidding() 에서 updateTradingCreatedAt() 해줍니다.

### 💫 작업 요약

- ReviewResponse 분리
- ReviewDetailResponse 에 거래 영수증을 위한 필드 추가
- Bidding 에 tradingCreatedAt 필드 추가 후 업데이트 로직 추가

### 🔍 중점적으로 리뷰 할 부분

- ReviewService
- BiddingService
- Bidding
- ReviewApiControllerTest