### PR TITLE
[feat] : 입찰 등록 API 개선

### DIFF
--- a/api/src/test/java/dev/handsup/auth/JwtAuthorizationArgumentResolverTest.java
+++ b/api/src/test/java/dev/handsup/auth/JwtAuthorizationArgumentResolverTest.java
@@ -49,7 +49,7 @@ class JwtAuthorizationArgumentResolverTest {
 	@DisplayName("[토큰이 유효하면 User 엔티티를 반환한다]")
 	void shouldResolveArgumentWithValidToken() {
 		// given
-		User user = UserFixture.user(1L);
+		User user = UserFixture.user1();
 		mockHttpServletRequest.addHeader(HttpHeaders.AUTHORIZATION, "Bearer validToken");
 		when(userService.getUserById(user.getId())).thenReturn(user);
 		when(webRequest.getNativeRequest(HttpServletRequest.class)).thenReturn(mockHttpServletRequest);

--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -12,14 +12,15 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.auth.service.JwtProvider;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
 import dev.handsup.bidding.dto.request.RegisterBiddingRequest;
@@ -28,29 +29,43 @@ import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.common.support.ApiTestSupport;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.BiddingFixture;
-import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
 import dev.handsup.user.domain.User;
+import dev.handsup.user.repository.UserRepository;
 
 @DisplayName("[BiddingApiController 테스트]")
 class BiddingApiControllerTest extends ApiTestSupport {
 
-	private final User bidder = UserFixture.user("bidder@gmail.com");
 	@Autowired
 	private ProductCategoryRepository productCategoryRepository;
 	@Autowired
 	private BiddingRepository biddingRepository;
-	private Auction auction;
-	private ProductCategory productCategory;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private JwtProvider jwtProvider;
+
+	private final User seller = user;
+	private String sellerAccessToken;
+	private final User bidder = UserFixture.user(2L, "bidder@naver.com");
+	private String bidderAccessToken;
+	private Auction auction1;
+	private Auction auction2;
 
 	@BeforeEach
 	void setUp() {
-		String DIGITAL_DEVICE = "디지털 기기";
-		productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
-		productCategoryRepository.save(productCategory);
-		auction = auctionRepository.save(AuctionFixture.auction(productCategory));
-		// 전체 테스트시 user 가 db 에서 삭제되는 오류
-		userRepository.saveAll(List.of(user, bidder));
+		userRepository.save(bidder);
+		sellerAccessToken = accessToken;
+		bidderAccessToken = jwtProvider.createAccessToken(bidder.getId());
+
+		auction1 = AuctionFixture.auction(seller);
+		productCategoryRepository.save(auction1.getProduct().getProductCategory());
+		auctionRepository.save(auction1);
+
+		auction2 = AuctionFixture.auction(seller);
+		ReflectionTestUtils.setField(auction2, "id", 2L);
+		productCategoryRepository.save(auction2.getProduct().getProductCategory());
+		auctionRepository.save(auction2);
 	}
 
 	@Test
@@ -62,8 +77,8 @@ class BiddingApiControllerTest extends ApiTestSupport {
 		// when
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders
-				.post("/api/auctions/{auctionId}/bids", auction.getId())
-				.header(AUTHORIZATION, "Bearer " + accessToken)
+				.post("/api/auctions/{auctionId}/bids", auction1.getId())
+				.header(AUTHORIZATION, "Bearer " + bidderAccessToken)
 				.contentType(APPLICATION_JSON)
 				.content(toJson(request))
 		);
@@ -72,11 +87,11 @@ class BiddingApiControllerTest extends ApiTestSupport {
 		resultActions.andExpectAll(
 			status().isOk(),
 			jsonPath("$.biddingPrice").value(10000),
-			jsonPath("$.auctionId").value(auction.getId()),
-			jsonPath("$.bidderId").value(user.getId()),
-			jsonPath("$.bidderNickname").value(user.getNickname()),
+			jsonPath("$.auctionId").value(auction1.getId()),
+			jsonPath("$.bidderId").value(bidder.getId()),
+			jsonPath("$.bidderNickname").value(bidder.getNickname()),
 			jsonPath("$.tradingStatus").value(TradingStatus.PREPARING.getLabel()),
-			jsonPath("$.imgUrl").value(user.getProfileImageUrl())
+			jsonPath("$.imgUrl").value(bidder.getProfileImageUrl())
 		);
 	}
 
@@ -84,13 +99,11 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	@Test
 	void getBidsOfAuctionTest() throws Exception {
 		// given
-		Auction auction2 = AuctionFixture.auction(productCategory);
-		auctionRepository.save(auction2);
 		List<Bidding> biddingList = List.of(
-			Bidding.of(40000, auction, user),
-			Bidding.of(20000, auction, user),
-			Bidding.of(30000, auction, user),
-			Bidding.of(50000, auction2, user)
+			Bidding.of(40000, auction1, bidder),
+			Bidding.of(20000, auction1, bidder),
+			Bidding.of(30000, auction1, bidder),
+			Bidding.of(50000, auction2, bidder)
 		);
 
 		biddingRepository.saveAll(biddingList);
@@ -98,7 +111,7 @@ class BiddingApiControllerTest extends ApiTestSupport {
 		// when
 		ResultActions resultActions = mockMvc.perform(
 			MockMvcRequestBuilders.get(
-					"/api/auctions/{auctionId}/bids", auction.getId())
+					"/api/auctions/{auctionId}/bids", auction1.getId())
 				.contentType(APPLICATION_JSON)
 				.param("page", "0")
 				.param("size", "10")
@@ -117,20 +130,18 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	@DisplayName("[[입찰 목록 상위 3개 조회 API] 한 경매의 입찰 목록 중에서 입찰가 기준 내림차순으로 3개를 조회한다]")
 	@Test
 	void getTop3BidsForAuctionTest() throws Exception {
-		Auction auction2 = AuctionFixture.auction(productCategory);
-		auctionRepository.save(auction2);
 		List<Bidding> biddingList = List.of(
-			Bidding.of(10000, auction, user),
-			Bidding.of(30000, auction, user),
-			Bidding.of(20000, auction, user),
-			Bidding.of(60000, auction, user),
-			Bidding.of(50000, auction, user),
-			Bidding.of(70000, auction2, user)
+			Bidding.of(10000, auction1, bidder),
+			Bidding.of(30000, auction1, bidder),
+			Bidding.of(20000, auction1, bidder),
+			Bidding.of(60000, auction1, bidder),
+			Bidding.of(50000, auction1, bidder),
+			Bidding.of(70000, auction2, bidder)
 		);
 		biddingRepository.saveAll(biddingList);
 
 		ResultActions resultActions = mockMvc.perform(
-			MockMvcRequestBuilders.get("/api/auctions/{auctionId}/bids/top3", auction.getId())
+			MockMvcRequestBuilders.get("/api/auctions/{auctionId}/bids/top3", auction1.getId())
 				.contentType(APPLICATION_JSON)
 		);
 
@@ -147,28 +158,28 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	@Test
 	void completeTrading() throws Exception {
 		//given
-		Bidding bidding = BiddingFixture.bidding(bidder, auction, TradingStatus.PROGRESSING);
+		Bidding bidding = BiddingFixture.bidding(bidder, auction1, TradingStatus.PROGRESSING);
 		biddingRepository.save(bidding);
 		//when, then
 		mockMvc.perform(patch("/api/auctions/bids/{biddingId}/complete", bidding.getId())
 				.contentType(APPLICATION_JSON)
-				.header(AUTHORIZATION, "Bearer " + accessToken))
+				.header(AUTHORIZATION, "Bearer " + sellerAccessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.tradingStatus").value(TradingStatus.COMPLETED.getLabel()))
-			.andExpect(jsonPath("$.auctionId").value(auction.getId()))
+			.andExpect(jsonPath("$.auctionId").value(auction1.getId()))
 			.andExpect(jsonPath("$.bidderId").value(bidder.getId()));
 	}
 
-	@DisplayName("[거래 상태가 진행중이 아니라면 거래를 완료할 수 없다.]")
+	@DisplayName("[판매자는 거래 상태가 진행중이 아니라면 거래를 완료할 수 없다.]")
 	@Test
 	void completeTrading_fails() throws Exception {
 		//given
-		Bidding bidding = BiddingFixture.bidding(bidder, auction, TradingStatus.WAITING);
+		Bidding bidding = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING);
 		biddingRepository.save(bidding);
 		//when, then
 		mockMvc.perform(patch("/api/auctions/bids/{biddingId}/complete", bidding.getId())
 				.contentType(APPLICATION_JSON)
-				.header(AUTHORIZATION, "Bearer " + accessToken))
+				.header(AUTHORIZATION, "Bearer " + sellerAccessToken))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code")
 				.value(BiddingErrorCode.CAN_NOT_COMPLETE_TRADING.getCode()));
@@ -179,31 +190,31 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	@Test
 	void cancelTrading() throws Exception {
 		//given
-		Bidding bidding1 = BiddingFixture.bidding(bidder, auction, TradingStatus.PROGRESSING);
-		Bidding bidding2 = BiddingFixture.bidding(bidder, auction, TradingStatus.WAITING);
+		Bidding bidding1 = BiddingFixture.bidding(bidder, auction1, TradingStatus.PROGRESSING);
+		Bidding bidding2 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING);
 		biddingRepository.saveAll(List.of(bidding1, bidding2));
 		//when, then
 		mockMvc.perform(patch("/api/auctions/bids/{biddingId}/cancel", bidding1.getId())
 				.contentType(APPLICATION_JSON)
-				.header(AUTHORIZATION, "Bearer " + accessToken))
+				.header(AUTHORIZATION, "Bearer " + sellerAccessToken))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.tradingStatus").value(TradingStatus.CANCELED.getLabel()))
-			.andExpect(jsonPath("$.auctionId").value(auction.getId()))
+			.andExpect(jsonPath("$.auctionId").value(auction1.getId()))
 			.andExpect(jsonPath("$.bidderId").value(bidder.getId()));
 
 		assertThat(bidding2.getTradingStatus()).isEqualTo(TradingStatus.PREPARING); // 변경 감지 위해 @Transactional 필요
 	}
 
-	@DisplayName("[거래가 진행중이 아니면 취소할 수 없다.]")
+	@DisplayName("[판매자는 거래가 진행중이 아니면 취소할 수 없다.]")
 	@Test
 	void cancelTrading_fails() throws Exception {
 		//given
-		Bidding bidding = BiddingFixture.bidding(bidder, auction, TradingStatus.COMPLETED);
+		Bidding bidding = BiddingFixture.bidding(bidder, auction1, TradingStatus.COMPLETED);
 		biddingRepository.save(bidding);
 		//when, then
 		mockMvc.perform(patch("/api/auctions/bids/{biddingId}/cancel", bidding.getId())
 				.contentType(APPLICATION_JSON)
-				.header(AUTHORIZATION, "Bearer " + accessToken))
+				.header(AUTHORIZATION, "Bearer " + sellerAccessToken))
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("$.code")
 				.value(BiddingErrorCode.CAN_NOT_CANCEL_TRADING.getCode()));

--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -36,6 +36,8 @@ import dev.handsup.user.repository.UserRepository;
 @DisplayName("[BiddingApiController 테스트]")
 class BiddingApiControllerTest extends ApiTestSupport {
 
+	private final User seller = user;
+	private final User bidder = UserFixture.user(2L, "bidder@naver.com");
 	@Autowired
 	private ProductCategoryRepository productCategoryRepository;
 	@Autowired
@@ -44,10 +46,7 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	private UserRepository userRepository;
 	@Autowired
 	private JwtProvider jwtProvider;
-
-	private final User seller = user;
 	private String sellerAccessToken;
-	private final User bidder = UserFixture.user(2L, "bidder@naver.com");
 	private String bidderAccessToken;
 	private Auction auction1;
 	private Auction auction2;

--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.auction.service.AuctionService;
 import dev.handsup.auth.service.JwtProvider;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
@@ -44,6 +46,8 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	private BiddingRepository biddingRepository;
 	@Autowired
 	private UserRepository userRepository;
+	@Autowired
+	private AuctionService auctionService;
 	@Autowired
 	private JwtProvider jwtProvider;
 	private String sellerAccessToken;
@@ -72,6 +76,7 @@ class BiddingApiControllerTest extends ApiTestSupport {
 	void registerBiddingTest() throws Exception {
 		// given
 		RegisterBiddingRequest request = RegisterBiddingRequest.from(10000);
+		int beforeBiddingCount = auction1.getBiddingCount();
 
 		// when
 		ResultActions resultActions = mockMvc.perform(
@@ -92,6 +97,9 @@ class BiddingApiControllerTest extends ApiTestSupport {
 			jsonPath("$.tradingStatus").value(TradingStatus.PREPARING.getLabel()),
 			jsonPath("$.imgUrl").value(bidder.getProfileImageUrl())
 		);
+
+		auction1 = auctionService.getAuctionById(this.auction1.getId());
+		assertThat(this.auction1.getBiddingCount()).isEqualTo(beforeBiddingCount + 1);
 	}
 
 	@DisplayName("[[입찰 목록 전체 조회 API] 한 경매의 모든 입찰 목록을 입찰가 기준 내림차순으로 조회한다]")

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.jdbc.Sql;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
@@ -33,9 +32,9 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 
 	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
+	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	private final User user = UserFixture.user();
 	private final User seller = UserFixture.user("seller@naver.com");
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired

--- a/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bookmark/controller/BookmarkApiControllerTest.java
@@ -11,9 +11,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.bookmark.domain.Bookmark;
@@ -22,7 +22,6 @@ import dev.handsup.bookmark.repository.BookmarkRepository;
 import dev.handsup.common.support.ApiTestSupport;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.BookmarkFixture;
-import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
 import dev.handsup.notification.repository.FCMTokenRepository;
 import dev.handsup.user.domain.User;
@@ -30,11 +29,8 @@ import dev.handsup.user.domain.User;
 @DisplayName("[Bookmark 통합 테스트]")
 class BookmarkApiControllerTest extends ApiTestSupport {
 
-	private final String DIGITAL_DEVICE = "디지털 기기";
-	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
-	private final Auction auction = AuctionFixture.auction(seller, productCategory);
-	private final User user = UserFixture.user();
-	private final User seller = UserFixture.user("seller@naver.com");
+	private Auction auction;
+	private User seller;
 	@Autowired
 	private BookmarkRepository bookmarkRepository;
 	@Autowired
@@ -46,14 +42,17 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 
 	@BeforeEach
 	void setUp() {
-		productCategoryRepository.save(productCategory);
+		seller = UserFixture.user2();
+		auction = AuctionFixture.auction(seller);
+
+		productCategoryRepository.save(auction.getProduct().getProductCategory());
 		userRepository.save(user);
 		userRepository.save(seller);
 		auctionRepository.save(auction);
 	}
 
-	@DisplayName("[북마크를 추가할 수 있다.]")
 	@Test
+	@DisplayName("[북마크를 추가할 수 있다.]")
 	void addBookmark() throws Exception {
 		// fcm 토큰 저장, seller 는 receiver
 		String fcmToken = "c1SuCte6bF--OIMW94J1tV:APA91bEU1mLbYiv7OwmHjKp0cpKZ9d64n7bDgkkkPtwk3iSLwbc"
@@ -67,8 +66,8 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.bookmarkCount").value(1));
 	}
 
-	@DisplayName("[북마크 추가 시 북마크가 존재하면 예외가 발생한다.]")
 	@Test
+	@DisplayName("[북마크 추가 시 북마크가 존재하면 예외가 발생한다.]")
 	void addBookmark_fails() throws Exception {
 		Bookmark bookmark = BookmarkFixture.bookmark(user, auction);
 		bookmarkRepository.save(bookmark);
@@ -83,8 +82,8 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 				.value(BookmarkErrorCode.ALREADY_EXISTS_BOOKMARK.getCode()));
 	}
 
-	@DisplayName("[북마크를 삭제할 수 있다.]")
 	@Test
+	@DisplayName("[북마크를 삭제할 수 있다.]")
 	void deleteBookmark() throws Exception {
 		Bookmark bookmark = BookmarkFixture.bookmark(user, auction);
 		bookmarkRepository.save(bookmark);
@@ -96,8 +95,8 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.bookmarkCount").value(auction.getBookmarkCount() - 1));
 	}
 
-	@DisplayName("[북마크 삭제 시 북마크가 존재하지 않으면 예외가 발생한다.]")
 	@Test
+	@DisplayName("[북마크 삭제 시 북마크가 존재하지 않으면 예외가 발생한다.]")
 	void deleteBookmark_fails() throws Exception {
 		mockMvc.perform(delete("/api/auctions/bookmarks/{auctionId}", auction.getId())
 				.contentType(APPLICATION_JSON)
@@ -107,8 +106,8 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.code").value(BookmarkErrorCode.NOT_FOUND_BOOKMARK.getCode()));
 	}
 
-	@DisplayName("[북마크가 없으면 북마크 여부 조회 시 false를 반환한다.]")
 	@Test
+	@DisplayName("[북마크가 없으면 북마크 여부 조회 시 false를 반환한다.]")
 	void getBookmarkStatusFalse() throws Exception {
 		mockMvc.perform(get("/api/auctions/bookmarks/{auctionId}", auction.getId())
 				.contentType(APPLICATION_JSON)
@@ -117,8 +116,8 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.isBookmarked").value(false));
 	}
 
-	@DisplayName("[북마크가 존재하면 북마크 여부 조회 시 true를 반환한다.]")
 	@Test
+	@DisplayName("[북마크가 존재하면 북마크 여부 조회 시 true를 반환한다.]")
 	void getBookmarkStatusTrue() throws Exception {
 		Bookmark bookmark = BookmarkFixture.bookmark(user, auction);
 		bookmarkRepository.save(bookmark);
@@ -129,10 +128,12 @@ class BookmarkApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.isBookmarked").value(true));
 	}
 
-	// @DisplayName("[북마크한 경매를 모두 조회할 수 있다.]")
 	@Test
+	@DisplayName("[북마크한 경매를 모두 조회할 수 있다.]")
 	void findUserBookmarks() throws Exception {
-		Auction auction2 = AuctionFixture.auction(productCategory);
+		Auction auction2 = AuctionFixture.auction(UserFixture.user(2L, "anothorSeller@naver.com"));
+		ReflectionTestUtils.setField(auction2, "id", 2L);
+		productCategoryRepository.save(auction2.getProduct().getProductCategory());
 		auctionRepository.save(auction2);
 
 		Bookmark bookmark1 = BookmarkFixture.bookmark(user, auction);

--- a/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
@@ -36,7 +36,7 @@ import dev.handsup.user.domain.User;
 class ChatRoomApiControllerTest extends ApiTestSupport {
 
 	private final User seller = user; // loginUser
-	private final User bidder = UserFixture.user("bidder@gmail.com");
+	private final User bidder = UserFixture.user2();
 	private ProductCategory productCategory;
 	private Auction auction;
 	private Bidding bidding;
@@ -115,7 +115,7 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 	@Test
 	void getUserChatRooms() throws Exception {
 		//given
-		User unrelatedUser = UserFixture.user("user@gmail.com");
+		User unrelatedUser = UserFixture.user(3L, "unrelatedUser@gmail.com");
 		userRepository.save(unrelatedUser);
 
 		Auction auction2 = AuctionFixture.auction(productCategory);
@@ -200,7 +200,7 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 	@Test
 	void getChatRoomWithBiddingId_fails() throws Exception {
 		//given
-		User unrelatedUser = UserFixture.user("user@gmail.com");
+		User unrelatedUser = UserFixture.user(3L, "unrelatedUser@gmail.com");
 		userRepository.save(unrelatedUser);
 		Auction unrelatedUserAuction = auctionRepository.save(AuctionFixture.auction(unrelatedUser, productCategory));
 		auctionRepository.save(unrelatedUserAuction);

--- a/api/src/test/java/dev/handsup/chat/controller/WebSocketTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/WebSocketTest.java
@@ -54,7 +54,7 @@ import dev.handsup.user.domain.User;
 class WebSocketTest extends ApiTestSupport {
 
 	private final User seller = user; // loginUser
-	private final User bidder = UserFixture.user("bidder@gmail.com");
+	private final User bidder = UserFixture.user2();
 	@LocalServerPort
 	private int port;
 	private BlockingQueue<ChatMessageResponse> chatMessageResponses;

--- a/api/src/test/java/dev/handsup/common/support/ApiTestSupport.java
+++ b/api/src/test/java/dev/handsup/common/support/ApiTestSupport.java
@@ -49,7 +49,7 @@ import lombok.extern.slf4j.Slf4j;
 @ExtendWith(DatabaseCleanerExtension.class)
 public abstract class ApiTestSupport extends TestContainerSupport {
 
-	protected final User user = UserFixture.user();
+	protected final User user = UserFixture.user1();
 	protected String accessToken;
 	protected String refreshToken;
 	@Autowired

--- a/api/src/test/java/dev/handsup/notification/controller/NotificationApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/notification/controller/NotificationApiControllerTest.java
@@ -47,7 +47,7 @@ class NotificationApiControllerTest extends ApiTestSupport {
 
 	@BeforeEach
 	void setUp() {
-		receiver = UserFixture.user("receiver@naver.com");
+		receiver = UserFixture.user2();
 		ReflectionTestUtils.setField(receiver, "readNotificationCount", 1);
 		userRepository.save(receiver);
 		receiverAccessToken = jwtProvider.createAccessToken(receiver.getId());

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -152,8 +152,8 @@ class UserApiControllerTest extends ApiTestSupport {
 	@DisplayName("[[유저 리뷰 조회 API] 유저의 리뷰가 생성된 시간 기준 내림차순으로 반환된다]")
 	void getUserReviewsTest() throws Exception {
 		// given
-		User seller = UserFixture.user();
-		User writer = UserFixture.user("writer@naver.com");
+		User seller = UserFixture.user1();
+		User writer = UserFixture.user2();
 
 		userRepository.saveAll(List.of(seller, writer));
 		Auction auction = AuctionFixture.auction(seller);

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -167,6 +167,14 @@ public class Auction extends TimeBaseEntity {
 		bookmarkCount--;
 	}
 
+	public void increaseBiddingCount() {
+		biddingCount++;
+	}
+
+	public void decreaseBiddingCount() {
+		biddingCount--;
+	}
+
 	public void updateCurrentBiddingPrice(int currentBiddingPrice) {
 		this.currentBiddingPrice = currentBiddingPrice;
 	}

--- a/core/src/main/java/dev/handsup/bidding/exception/BiddingErrorCode.java
+++ b/core/src/main/java/dev/handsup/bidding/exception/BiddingErrorCode.java
@@ -15,7 +15,8 @@ public enum BiddingErrorCode implements ErrorCode {
 	CAN_NOT_PREPARE_TRADING("거래를 준비할 수 없는 상태입니다.", "B_005"),
 
 	CAN_NOT_PROGRESS_TRADING("거래를 진행할 수 없는 상태입니다.", "B_006"),
-	NOT_AUTHORIZED_SELLER("거래 상태를 판매자만 변경 가능합니다.", "B_007");
+	NOT_AUTHORIZED_SELLER("거래 상태를 판매자만 변경 가능합니다.", "B_007"),
+	NOT_ALLOW_SELF_BIDDING("판매자는 자신의 경매에 입찰을 할 수 없습니다.", "B_009");
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -52,6 +52,11 @@ public class BiddingService {
 	@Transactional
 	public BiddingResponse registerBidding(RegisterBiddingRequest request, Long auctionId, User bidder) {
 		Auction auction = auctionService.getAuctionById(auctionId);
+
+		if (auction.getSeller().equals(bidder)) {
+			throw new ValidationException(BiddingErrorCode.NOT_ALLOW_SELF_BIDDING);
+		}
+
 		validateBiddingPrice(request.biddingPrice(), auction);
 
 		Bidding savedBidding = biddingRepository.save(
@@ -61,6 +66,8 @@ public class BiddingService {
 			savedBidding.updateTradingStatusPreparing(); // 첫 입찰일 경우 준비중 상태로 변경
 		}
 		auction.updateCurrentBiddingPrice(savedBidding.getBiddingPrice());
+		auction.increaseBiddingCount();
+
 		return BiddingMapper.toBiddingResponse(savedBidding);
 	}
 

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -50,7 +50,7 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 		category = ProductFixture.productCategory(DIGITAL_DEVICE);
 		productCategoryRepository.save(category);
 
-		user = UserFixture.user();
+		user = UserFixture.user1();
 		userRepository.save(user);
 	}
 

--- a/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
@@ -45,7 +45,7 @@ import dev.handsup.user.domain.User;
 @DisplayName("[경매 서비스 테스트]")
 @ExtendWith(MockitoExtension.class)
 class AuctionServiceTest {
-	private final User user = UserFixture.user();
+	private final User user = UserFixture.user1();
 	private final String DIGITAL_DEVICE = "디지털 기기";
 	private final ProductCategory productCategory = ProductFixture.productCategory(DIGITAL_DEVICE);
 	private final Auction auction = AuctionFixture.auction();
@@ -96,7 +96,7 @@ class AuctionServiceTest {
 		given(auctionRepository.save(any(Auction.class))).willReturn(auction);
 
 		// when
-		AuctionDetailResponse response = auctionService.registerAuction(request, UserFixture.user());
+		AuctionDetailResponse response = auctionService.registerAuction(request, UserFixture.user1());
 
 		// then
 		assertAll(

--- a/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
+++ b/core/src/test/java/dev/handsup/auth/service/AuthServiceTest.java
@@ -31,7 +31,7 @@ import dev.handsup.user.service.UserService;
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
 
-	private final User user = UserFixture.user(1L);
+	private final User user = UserFixture.user1();
 	private final LoginRequest loginRequest = LoginRequest.of(
 		user.getEmail(), user.getPassword()
 	);

--- a/core/src/test/java/dev/handsup/bidding/repository/BiddingRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/bidding/repository/BiddingRepositoryTest.java
@@ -20,7 +20,7 @@ import dev.handsup.user.domain.User;
 class BiddingRepositoryTest extends DataJpaTestSupport {
 
 	private final Auction auction = AuctionFixture.auction();
-	private final User bidder = UserFixture.user();
+	private final User bidder = UserFixture.user1();
 	@Autowired
 	private BiddingRepository biddingRepository;
 

--- a/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
+++ b/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
@@ -40,7 +40,7 @@ import dev.handsup.user.domain.User;
 class BiddingServiceTest {
 
 	private final Auction auction = AuctionFixture.auction();    // 최소 입찰가 10000원
-	private final User user = UserFixture.user();
+	private final User user = UserFixture.user1();
 	@Mock
 	private BiddingRepository biddingRepository;
 	@Mock
@@ -146,7 +146,7 @@ class BiddingServiceTest {
 	@Test
 	void completeTrading() {
 		//given
-		User bidder = UserFixture.user("bidder@gmail.com");
+		User bidder = UserFixture.user2();
 		Bidding bidding = BiddingFixture.bidding(auction, bidder, TradingStatus.PROGRESSING);
 		ReflectionTestUtils.setField(bidding, "createdAt", LocalDateTime.now());
 
@@ -164,7 +164,7 @@ class BiddingServiceTest {
 	@Test
 	void cancelTrading() {
 		//given
-		User bidder = UserFixture.user("bidder@gmail.com");
+		User bidder = UserFixture.user2();
 		Bidding bidding1 = BiddingFixture.bidding(auction, bidder, TradingStatus.PROGRESSING, 40000);
 		ReflectionTestUtils.setField(bidding1, "createdAt", LocalDateTime.now());
 

--- a/core/src/test/java/dev/handsup/bookmark/service/BookmarkServiceTest.java
+++ b/core/src/test/java/dev/handsup/bookmark/service/BookmarkServiceTest.java
@@ -35,9 +35,9 @@ import dev.handsup.user.domain.User;
 @DisplayName("[BookmarkService 테스트]")
 @ExtendWith(MockitoExtension.class)
 class BookmarkServiceTest {
-	private final User user = UserFixture.user();
+	private final User user = UserFixture.user1();
 	private final PageRequest pageRequest = PageRequest.of(0, 5);
-	private final Auction auction = AuctionFixture.auction(UserFixture.user("seller@naver.com"));
+	private final Auction auction = AuctionFixture.auction(UserFixture.user2());
 	@Mock
 	private AuctionRepository auctionRepository;
 	@Mock

--- a/core/src/test/java/dev/handsup/chat/repository/ChatRoomRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/chat/repository/ChatRoomRepositoryTest.java
@@ -51,9 +51,9 @@ class ChatRoomRepositoryTest extends DataJpaTestSupport {
 		ProductCategory category = ProductFixture.productCategory("디지털 기기");
 		productCategoryRepository.save(category);
 
-		user1 = UserFixture.user("user1@gmail.com");
-		user2 = UserFixture.user("user2@gmail.com");
-		user3 = UserFixture.user("user3@gmail.com");
+		user1 = UserFixture.user1();
+		user2 = UserFixture.user2();
+		user3 = UserFixture.user(3L, "user3@naver.com");
 		userRepository.saveAll(List.of(user1, user2, user3));
 
 		auction1 = AuctionFixture.auction(category);

--- a/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
+++ b/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
@@ -39,8 +39,8 @@ import dev.handsup.user.repository.UserRepository;
 @ExtendWith(MockitoExtension.class)
 class ChatRoomServiceTest {
 
-	private final User seller = UserFixture.user(1L);
-	private final User bidder = UserFixture.user(2L);
+	private final User seller = UserFixture.user1();
+	private final User bidder = UserFixture.user2();
 	private PageRequest pageRequest = PageRequest.of(0, 5);
 	@Mock
 	private AuctionRepository auctionRepository;

--- a/core/src/test/java/dev/handsup/notification/domain/service/FCMServiceTest.java
+++ b/core/src/test/java/dev/handsup/notification/domain/service/FCMServiceTest.java
@@ -29,7 +29,7 @@ import dev.handsup.user.domain.User;
 @ExtendWith(MockitoExtension.class)
 class FCMServiceTest {
 
-	private final User receiver = UserFixture.user();
+	private final User receiver = UserFixture.user1();
 	private final Auction auction = AuctionFixture.auction();
 	@Mock
 	private FCMTokenRepository fcmTokenRepository;

--- a/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
+++ b/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
@@ -39,7 +39,7 @@ import dev.handsup.user.repository.UserReviewLabelRepository;
 class ReviewServiceTest {
 
 	private final Auction auction = AuctionFixture.auction();
-	private final User writer = UserFixture.user();
+	private final User writer = UserFixture.user1();
 	private final Review review = ReviewFixture.review();
 	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
 		1L, ReviewLabelValue.MANNER.getDescription()

--- a/core/src/test/java/dev/handsup/user/repository/UserReviewLabelRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/user/repository/UserReviewLabelRepositoryTest.java
@@ -20,7 +20,7 @@ import dev.handsup.user.domain.User;
 @DisplayName("[UserReviewLabelRepository 테스트]")
 class UserReviewLabelRepositoryTest extends DataJpaTestSupport {
 
-	private final User user = UserFixture.user();
+	private final User user = UserFixture.user1();
 	@Autowired
 	private TestEntityManager entityManager;
 	@Autowired

--- a/core/src/test/java/dev/handsup/user/service/UserServiceTest.java
+++ b/core/src/test/java/dev/handsup/user/service/UserServiceTest.java
@@ -33,7 +33,7 @@ import dev.handsup.user.repository.UserRepository;
 @DisplayName("[UserService 테스트]")
 class UserServiceTest {
 
-	private final User user = UserFixture.user();
+	private final User user = UserFixture.user1();
 	private final JoinUserRequest request = JoinUserRequest.of(
 		user.getEmail(),
 		user.getPassword(),
@@ -94,7 +94,7 @@ class UserServiceTest {
 		given(encryptHelper.encrypt(request.password()))
 			.willReturn("encryptedPassword");
 
-		User savedUser = UserFixture.user(1L);
+		User savedUser = UserFixture.user1();
 		given(userRepository.save(any(User.class)))
 			.willReturn(savedUser);
 

--- a/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/AuctionFixture.java
@@ -29,7 +29,7 @@ public class AuctionFixture {
 	public static Auction auction() {
 		return Auction.of(
 			3L,
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			ProductCategory.from(DIGITAL_DEVICE),
 			10000,
@@ -66,7 +66,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,
@@ -103,7 +103,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, Integer initPrice) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			initPrice,
@@ -121,7 +121,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, ProductStatus productStatus) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,
@@ -139,7 +139,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, TradeMethod tradeMethod) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,
@@ -157,7 +157,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, String title) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			title,
 			productCategory,
 			10000,
@@ -175,7 +175,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, String title, int initPrice) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			title,
 			productCategory,
 			initPrice,
@@ -193,7 +193,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, String si, String gu, String dong) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,
@@ -211,7 +211,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, String endDate, String si, String gu, String dong) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,
@@ -229,7 +229,7 @@ public class AuctionFixture {
 
 	public static Auction auction(ProductCategory productCategory, LocalDate endDate) {
 		return Auction.of(
-			UserFixture.user(),
+			UserFixture.user1(),
 			TITLE,
 			productCategory,
 			10000,

--- a/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/ReviewFixture.java
@@ -13,7 +13,7 @@ public final class ReviewFixture {
 	static final int EVALUATION_SCORE = 2;
 	static final String CONTENT = "저렴한 가격에 좋은 물건을 잘 구매했어요!";
 	static final Auction AUCTION = AuctionFixture.auction();
-	static final User WRITER = UserFixture.user();
+	static final User WRITER = UserFixture.user1();
 
 	public static Review review() {
 		return Review.of(EVALUATION_SCORE, CONTENT, AUCTION, WRITER);

--- a/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
@@ -27,4 +27,8 @@ public final class UserFixture {
 	public static User user(String email) {
 		return User.of(email, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
 	}
+
+	public static User user(Long id, String email) {
+		return User.getTestUser(id, email, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
+	}
 }

--- a/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/UserFixture.java
@@ -9,23 +9,18 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class UserFixture {
 
-	static final String EMAIL = "hello123@naver.com";
 	static final String PASSWORD = "password123";
 	static final String NICKNAME = "nickname123";
 	static final String PROFILE_IMAGE_URL =
 		"https://lh3.googleusercontent.com/a/ACg8ocI5mIsHlnobowJ34VO9ZN8G31hlB4OBBRo_JoWItp5Vyg=s288-c-no";
 	static final Address address = Address.of("서울시", "구로구", "가리봉동");
 
-	public static User user() {
-		return User.getTestUser(1L, EMAIL, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
+	public static User user1() {
+		return User.getTestUser(1L, "hello1@naver.com", PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
 	}
 
-	public static User user(Long id) {
-		return User.getTestUser(id, EMAIL, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
-	}
-
-	public static User user(String email) {
-		return User.of(email, PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
+	public static User user2() {
+		return User.getTestUser(2L, "hello2@naver.com", PASSWORD, NICKNAME, address, PROFILE_IMAGE_URL);
 	}
 
 	public static User user(Long id, String email) {

--- a/core/src/testFixtures/java/dev/handsup/fixture/UserReviewLabelFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/UserReviewLabelFixture.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class UserReviewLabelFixture {
 
-	static final User user = UserFixture.user();
+	static final User user = UserFixture.user1();
 
 	public static UserReviewLabel userReviewLabel(Long id, ReviewLabel reviewLabel) {
 		return new UserReviewLabel(id, reviewLabel);


### PR DESCRIPTION
close #103

### 💫 작업 요약

- 입찰 등록할 때, 경매의 biddingCount 를 갱신해줍니다.
- 작업 2 자신의 경매에는 입찰을 등록할 수 없도록 강제합니다.
- ApiControllerTest 관련하여 UserFixture 생성이 어색해서, user1, user2 를 만들어서 리팩토링 했습니다.

### 🔍 중점적으로 리뷰 할 부분

- BiddingService
- BiddingApiControllerTest