### PR TITLE
[feat] : 경매 입찰 종료 시 스케줄러로 경매, 입찰 상태 변경

### DIFF
--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -19,6 +19,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.auction.service.AuctionService;
 import dev.handsup.auth.service.JwtProvider;
@@ -160,10 +161,12 @@ class BiddingApiControllerTest extends ApiTestSupport {
 		).andDo(MockMvcResultHandlers.print());
 	}
 
+	@Transactional
 	@DisplayName("[판매자는 진행 중인 거래를 완료 상태로 변경할 수 있다.]")
 	@Test
 	void completeTrading() throws Exception {
 		//given
+		ReflectionTestUtils.setField(auction1, "status", AuctionStatus.TRADING); //변경 감지
 		Bidding bidding = BiddingFixture.bidding(bidder, auction1, TradingStatus.PROGRESSING);
 		biddingRepository.save(bidding);
 		//when, then

--- a/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/bidding/controller/BiddingApiControllerTest.java
@@ -93,7 +93,7 @@ class BiddingApiControllerTest extends ApiTestSupport {
 			jsonPath("$.auctionId").value(auction1.getId()),
 			jsonPath("$.bidderId").value(bidder.getId()),
 			jsonPath("$.bidderNickname").value(bidder.getNickname()),
-			jsonPath("$.tradingStatus").value(TradingStatus.PREPARING.getLabel()),
+			jsonPath("$.tradingStatus").value(TradingStatus.WAITING.getLabel()),
 			jsonPath("$.imgUrl").value(bidder.getProfileImageUrl())
 		);
 

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -160,8 +160,9 @@ public class Auction extends TimeBaseEntity {
 	public void changeAuctionStatusTrading() {
 		status = AuctionStatus.TRADING;
 	}
+
 	public void changeAuctionStatusCompleted() {
-		if (status!=TRADING){
+		if (status != TRADING) {
 			throw new ValidationException(AuctionErrorCode.CAN_NOT_COMPLETE_AUCTION);
 		}
 		status = COMPLETED;

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -21,7 +21,9 @@ import dev.handsup.auction.domain.auction_field.TradingLocation;
 import dev.handsup.auction.domain.product.Product;
 import dev.handsup.auction.domain.product.ProductStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.auction.exception.AuctionErrorCode;
 import dev.handsup.common.entity.TimeBaseEntity;
+import dev.handsup.common.exception.ValidationException;
 import dev.handsup.user.domain.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embedded;
@@ -157,6 +159,12 @@ public class Auction extends TimeBaseEntity {
 
 	public void changeAuctionStatusTrading() {
 		status = AuctionStatus.TRADING;
+	}
+	public void changeAuctionStatusCompleted() {
+		if (status!=TRADING){
+			throw new ValidationException(AuctionErrorCode.CAN_NOT_COMPLETE_AUCTION);
+		}
+		status = COMPLETED;
 	}
 
 	public void increaseBookmarkCount() {

--- a/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
+++ b/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
@@ -14,7 +14,9 @@ public enum AuctionErrorCode implements ErrorCode {
 	NOT_FOUND_TADE_METHOD("거래 방법을 올바르게 입력해주세요.", "AU_003"),
 	NOT_FOUND_PRODUCT_CATEGORY("상품 카테고리를 올바르게 입력해주세요.", "AU_004"),
 	INVALID_SORT_INPUT("정렬 기준을 올바르게 입력해주세요.", "AU_005"),
-	EMPTY_SORT_INPUT("정렬 기준을 입력해주세요.", "AU_006");
+	EMPTY_SORT_INPUT("정렬 기준을 입력해주세요.", "AU_006"),
+	CAN_NOT_COMPLETE_AUCTION("경매를 완료 상태로 변경할 수 없습니다.", "AU_007");
+
 	private final String message;
 	private final String code;
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
@@ -15,4 +15,6 @@ public interface AuctionQueryRepository {
 	Slice<Auction> sortAuctionByCriteria(String si, String gu, String dong, Pageable pageable);
 
 	Slice<Auction> findByProductCategories(List<ProductCategory> productCategories, Pageable pageable);
+
+	void updateAuctionStatusTrading();
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -5,12 +5,14 @@ import static dev.handsup.auction.domain.product.QProduct.*;
 import static dev.handsup.auction.domain.product.product_category.QProductCategory.*;
 import static org.springframework.util.StringUtils.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
@@ -92,6 +94,16 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 			.fetch();
 		boolean hasNext = hasNext(pageable.getPageSize(), content);
 		return new SliceImpl<>(content, pageable, hasNext);
+	}
+
+	@Override
+	@Transactional
+	public void updateAuctionStatusTrading() {
+		queryFactory
+			.update(auction)
+			.set(auction.status, AuctionStatus.TRADING)
+			.where(auction.endDate.eq(LocalDate.now().minusDays(1)))
+			.execute();
 	}
 
 	private OrderSpecifier<?> searchAuctionSort(Pageable pageable) {

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
@@ -1,17 +1,12 @@
 package dev.handsup.auction.repository.auction;
 
-import java.time.LocalDate;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.user.domain.User;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
@@ -19,14 +14,4 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@Query("select distinct b.auction from Bookmark b " +
 		"where b.user = :user")
 	Slice<Auction> findBookmarkAuction(@Param("user") User user, Pageable pageable);
-
-	@Transactional
-	@Modifying(clearAutomatically = true)
-	@Query("update Auction a set a.status = :newStatus "
-		+ "where a.status = :currentStatus and a.endDate < :todayDate")
-	void updateAuctionStatus(
-		@Param("currentStatus") AuctionStatus currentStatus,
-		@Param("newStatus") AuctionStatus newStatus,
-		@Param("todayDate") LocalDate todayDate
-	);
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
@@ -15,7 +15,6 @@ import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.user.domain.User;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
-	Boolean existsByStatus(AuctionStatus status);
 
 	@Query("select distinct b.auction from Bookmark b " +
 		"where b.user = :user")

--- a/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
+++ b/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
@@ -1,12 +1,9 @@
 package dev.handsup.auction.scheduler;
 
-import java.time.LocalDate;
-
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-import dev.handsup.auction.domain.auction_field.AuctionStatus;
-import dev.handsup.auction.repository.auction.AuctionRepository;
+import dev.handsup.auction.repository.auction.AuctionQueryRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -14,10 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class AuctionScheduler {
-	private final AuctionRepository auctionRepository;
+	private final AuctionQueryRepository auctionQueryRepository;
 
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void updateAuctionStatus() {
-		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING, LocalDate.now());
+		auctionQueryRepository.updateAuctionStatusTrading();
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
+++ b/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
@@ -1,6 +1,5 @@
 package dev.handsup.auction.scheduler;
 
-import java.text.SimpleDateFormat;
 import java.time.LocalDate;
 
 import org.springframework.scheduling.annotation.Scheduled;
@@ -16,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AuctionScheduler {
 	private final AuctionRepository auctionRepository;
-	private final SimpleDateFormat dateFormat = new SimpleDateFormat("HH:mm:ss");
 
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void updateAuctionStatus() {

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
@@ -1,0 +1,11 @@
+package dev.handsup.bidding.repository;
+
+import java.util.Optional;
+
+import dev.handsup.auction.domain.Auction;
+import dev.handsup.bidding.domain.Bidding;
+
+public interface BiddingQueryRepository {
+
+	Optional<Bidding> findWaitingBiddingLatest(Auction auction);
+}

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
@@ -8,4 +8,5 @@ import dev.handsup.bidding.domain.Bidding;
 public interface BiddingQueryRepository {
 
 	Optional<Bidding> findWaitingBiddingLatest(Auction auction);
+	void updateBiddingTradingStatus();
 }

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepository.java
@@ -8,5 +8,6 @@ import dev.handsup.bidding.domain.Bidding;
 public interface BiddingQueryRepository {
 
 	Optional<Bidding> findWaitingBiddingLatest(Auction auction);
+
 	void updateBiddingTradingStatus();
 }

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingQueryRepositoryImpl.java
@@ -1,0 +1,34 @@
+package dev.handsup.bidding.repository;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.QAuction;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.domain.QBidding;
+import dev.handsup.bidding.domain.TradingStatus;
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class BiddingQueryRepositoryImpl implements BiddingQueryRepository {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Optional<Bidding> findWaitingBiddingLatest(Auction auction) {
+		Bidding bidding = queryFactory.select(QBidding.bidding)
+			.from(QBidding.bidding)
+			.where(
+				QAuction.auction.eq(auction),
+				QBidding.bidding.tradingStatus.eq(TradingStatus.WAITING)
+			)
+			.orderBy(QBidding.bidding.createdAt.desc())
+			.fetchFirst();
+		return Optional.ofNullable(bidding);
+	}
+}

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 
 import dev.handsup.bidding.domain.Bidding;
 
-public interface BiddingRepository extends JpaRepository<Bidding, Long>{
+public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
 	@Query("SELECT MAX(b.biddingPrice) FROM Bidding b WHERE b.auction.id = :auctionId")
 	Integer findMaxBiddingPriceByAuctionId(Long auctionId);

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -1,21 +1,16 @@
 package dev.handsup.bidding.repository;
 
-import java.util.Optional;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import dev.handsup.bidding.domain.Bidding;
-import dev.handsup.bidding.domain.TradingStatus;
 
-public interface BiddingRepository extends JpaRepository<Bidding, Long> {
+public interface BiddingRepository extends JpaRepository<Bidding, Long>{
 
 	@Query("SELECT MAX(b.biddingPrice) FROM Bidding b WHERE b.auction.id = :auctionId")
 	Integer findMaxBiddingPriceByAuctionId(Long auctionId);
 
 	Slice<Bidding> findByAuctionIdOrderByBiddingPriceDesc(Long auctionId, Pageable pageable);
-
-	Optional<Bidding> findFirstByTradingStatus(TradingStatus tradingStatus);
 }

--- a/core/src/main/java/dev/handsup/bidding/scheduler/BiddingScheduler.java
+++ b/core/src/main/java/dev/handsup/bidding/scheduler/BiddingScheduler.java
@@ -1,0 +1,21 @@
+package dev.handsup.bidding.scheduler;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import dev.handsup.bidding.repository.BiddingQueryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class BiddingScheduler {
+
+	private BiddingQueryRepository biddingQueryRepository;
+
+	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+	public void updateTradingStatus() {
+		biddingQueryRepository.updateBiddingTradingStatus();
+	}
+}

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -10,11 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.service.AuctionService;
 import dev.handsup.bidding.domain.Bidding;
-import dev.handsup.bidding.domain.TradingStatus;
 import dev.handsup.bidding.dto.BiddingMapper;
 import dev.handsup.bidding.dto.request.RegisterBiddingRequest;
 import dev.handsup.bidding.dto.response.BiddingResponse;
 import dev.handsup.bidding.exception.BiddingErrorCode;
+import dev.handsup.bidding.repository.BiddingQueryRepository;
 import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.common.dto.CommonMapper;
 import dev.handsup.common.dto.PageResponse;
@@ -28,6 +28,7 @@ import lombok.RequiredArgsConstructor;
 public class BiddingService {
 
 	private final BiddingRepository biddingRepository;
+	private final BiddingQueryRepository biddingQueryRepository;
 	private final AuctionService auctionService;
 	private boolean isFirstBidding;
 
@@ -96,7 +97,7 @@ public class BiddingService {
 		Bidding bidding = findBiddingById(biddingId);
 		validateAuthorization(bidding, seller);
 		bidding.updateTradingStatusCanceled();
-		biddingRepository.findFirstByTradingStatus(TradingStatus.WAITING) // 다음 입찰 준비중 상태로 변경
+		biddingQueryRepository.findWaitingBiddingLatest(bidding.getAuction()) // 다음 입찰 준비중 상태로 변경
 			.ifPresent(Bidding::updateTradingStatusPreparing);
 		return BiddingMapper.toBiddingResponse(bidding);
 	}

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -81,7 +81,7 @@ public class BiddingService {
 		validateAuthorization(bidding, seller);
 		bidding.updateTradingStatusComplete();
 		bidding.getAuction().updateBuyer(bidding.getBidder());
-
+		bidding.getAuction().changeAuctionStatusCompleted();
 		//
 
 		return BiddingMapper.toBiddingResponse(bidding);

--- a/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
+++ b/core/src/main/java/dev/handsup/bidding/service/BiddingService.java
@@ -30,15 +30,12 @@ public class BiddingService {
 	private final BiddingRepository biddingRepository;
 	private final BiddingQueryRepository biddingQueryRepository;
 	private final AuctionService auctionService;
-	private boolean isFirstBidding;
 
 	private void validateBiddingPrice(int biddingPrice, Auction auction) {
-		isFirstBidding = false;
 		Integer maxBiddingPrice = biddingRepository.findMaxBiddingPriceByAuctionId(auction.getId());
 
 		if (maxBiddingPrice == null) {
 			// 입찰 내역이 없는 경우, 최소 입찰가부터 입찰 가능
-			isFirstBidding = true;
 			if (biddingPrice < auction.getInitPrice()) {
 				throw new ValidationException(BiddingErrorCode.BIDDING_PRICE_LESS_THAN_INIT_PRICE);
 			}
@@ -63,9 +60,7 @@ public class BiddingService {
 		Bidding savedBidding = biddingRepository.save(
 			BiddingMapper.toBidding(request, auction, bidder)
 		);
-		if (isFirstBidding) {
-			savedBidding.updateTradingStatusPreparing(); // 첫 입찰일 경우 준비중 상태로 변경
-		}
+
 		auction.updateCurrentBiddingPrice(savedBidding.getBiddingPrice());
 		auction.increaseBiddingCount();
 

--- a/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/auction/repository/auction/AuctionRepositoryTest.java
@@ -26,6 +26,7 @@ import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 
 @DisplayName("[AuctionRepository 테스트]")
 class AuctionRepositoryTest extends DataJpaTestSupport {
@@ -34,7 +35,13 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 	private final PageRequest pageRequest = PageRequest.of(0, 10);
 
 	@Autowired
+	private EntityManager em;
+
+	@Autowired
 	private AuctionRepository auctionRepository;
+
+	@Autowired
+	private AuctionQueryRepository auctionQueryRepository;
 	@Autowired
 	private UserRepository userRepository;
 	@Autowired
@@ -90,8 +97,12 @@ class AuctionRepositoryTest extends DataJpaTestSupport {
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
 
 		//when
-		auctionRepository.updateAuctionStatus(AuctionStatus.BIDDING, AuctionStatus.TRADING,
-			today); //벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
+		//벌크 업데이트(영속성 컨텍스트 거치지 않음) 후 영속성 컨텍스트 비움
+		auctionQueryRepository.updateAuctionStatusTrading();
+
+		em.flush();
+		em.clear();
+
 		Auction savedAuction1 = auctionRepository.findById(auction1.getId()).orElseThrow();
 		Auction savedAuction2 = auctionRepository.findById(auction2.getId()).orElseThrow();
 		Auction savedAuction3 = auctionRepository.findById(auction3.getId()).orElseThrow();

--- a/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
@@ -64,7 +64,7 @@ class BiddingQueryRepositoryTest extends DataJpaTestSupport {
 	@Test
 	@DisplayName("[경매 내 대기 상태 입찰들 중 가장 최신 입찰(=가격 높은 입찰)을 조회한다.]")
 	void findWaitingBiddingLatest() {
-	    //given
+		//given
 		Bidding waitingBidding1 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING, 2000);
 		Bidding waitingBidding2 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING, 3000);
 		Bidding anotherAuctionBidding = BiddingFixture.bidding(bidder, auction2, TradingStatus.WAITING, 4000);

--- a/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
@@ -1,0 +1,72 @@
+package dev.handsup.bidding.repository;
+
+import java.util.List;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.auction.repository.auction.AuctionRepository;
+import dev.handsup.auction.repository.product.ProductCategoryRepository;
+import dev.handsup.bidding.domain.Bidding;
+import dev.handsup.bidding.domain.TradingStatus;
+import dev.handsup.common.support.DataJpaTestSupport;
+import dev.handsup.config.TestAuditingConfig;
+import dev.handsup.fixture.AuctionFixture;
+import dev.handsup.fixture.BiddingFixture;
+import dev.handsup.fixture.ProductFixture;
+import dev.handsup.fixture.UserFixture;
+import dev.handsup.user.domain.User;
+import dev.handsup.user.repository.UserRepository;
+
+@Import(TestAuditingConfig.class)
+@DisplayName("[BiddingQueryRepository 테스트]")
+class BiddingQueryRepositoryTest extends DataJpaTestSupport {
+
+	private Auction auction1, auction2;
+	private User bidder;
+	@Autowired
+	private ProductCategoryRepository productCategoryRepository;
+
+	@Autowired
+	private BiddingQueryRepository biddingQueryRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private BiddingRepository biddingRepository;
+
+	@Autowired
+	private AuctionRepository auctionRepository;
+
+	@BeforeEach
+	void setUp() {
+		ProductCategory category = productCategoryRepository.save(ProductFixture.productCategory("디지털 기기"));
+		auction1 = auctionRepository.save(AuctionFixture.auction(category));
+		auction2 = auctionRepository.save(AuctionFixture.auction(category));
+		bidder = userRepository.save(UserFixture.user2());
+	}
+
+	@Test
+	@DisplayName("[경매 내 대기 상태 입찰들 중 가장 최신 입찰(=가격 높은 입찰)을 조회한다.]")
+	void findWaitingBiddingLatest() {
+	    //given
+		Bidding waitingBidding1 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING, 2000);
+		Bidding waitingBidding2 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING, 3000);
+		Bidding anotherAuctionBidding = BiddingFixture.bidding(bidder, auction2, TradingStatus.WAITING, 4000);
+		Bidding progressingBidding = BiddingFixture.bidding(bidder, auction1, TradingStatus.PROGRESSING, 5000);
+		biddingRepository.saveAll(List.of(waitingBidding1, waitingBidding2, anotherAuctionBidding, progressingBidding));
+
+		//when
+		Bidding actualBidding = biddingQueryRepository.findWaitingBiddingLatest(auction1).orElseThrow();
+
+		//then
+		Assertions.assertThat(actualBidding.getId()).isEqualTo(waitingBidding2.getId());
+	}
+}

--- a/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/bidding/repository/BiddingQueryRepositoryTest.java
@@ -1,13 +1,16 @@
 package dev.handsup.bidding.repository;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDate;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
@@ -23,12 +26,13 @@ import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.repository.UserRepository;
+import jakarta.persistence.EntityManager;
 
 @Import(TestAuditingConfig.class)
 @DisplayName("[BiddingQueryRepository 테스트]")
 class BiddingQueryRepositoryTest extends DataJpaTestSupport {
 
-	private Auction auction1, auction2;
+	private Auction auction1, auction2, auction3;
 	private User bidder;
 	@Autowired
 	private ProductCategoryRepository productCategoryRepository;
@@ -45,11 +49,15 @@ class BiddingQueryRepositoryTest extends DataJpaTestSupport {
 	@Autowired
 	private AuctionRepository auctionRepository;
 
+	@Autowired
+	private EntityManager em;
+
 	@BeforeEach
 	void setUp() {
 		ProductCategory category = productCategoryRepository.save(ProductFixture.productCategory("디지털 기기"));
 		auction1 = auctionRepository.save(AuctionFixture.auction(category));
 		auction2 = auctionRepository.save(AuctionFixture.auction(category));
+		auction3 = auctionRepository.save(AuctionFixture.auction(category));
 		bidder = userRepository.save(UserFixture.user2());
 	}
 
@@ -67,6 +75,42 @@ class BiddingQueryRepositoryTest extends DataJpaTestSupport {
 		Bidding actualBidding = biddingQueryRepository.findWaitingBiddingLatest(auction1).orElseThrow();
 
 		//then
-		Assertions.assertThat(actualBidding.getId()).isEqualTo(waitingBidding2.getId());
+		assertThat(actualBidding.getId()).isEqualTo(waitingBidding2.getId());
+	}
+
+	@Test
+	@DisplayName("[경매 종료일이 하루 지난 각 경매들에서 최신 입찰을 조회해 상태를 업데이트한다.]")
+	void updateBiddingTradingStatus() {
+		//given
+		ReflectionTestUtils.setField(auction1, "endDate", LocalDate.now().minusDays(1));
+		ReflectionTestUtils.setField(auction2, "endDate", LocalDate.now().minusDays(1));
+		ReflectionTestUtils.setField(auction3, "endDate", LocalDate.now());
+
+		Bidding auction1Bidding1 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING);
+		Bidding auction1Bidding2 = BiddingFixture.bidding(bidder, auction1, TradingStatus.WAITING);
+		Bidding auction2Bidding1 = BiddingFixture.bidding(bidder, auction2, TradingStatus.WAITING);
+		Bidding auction2Bidding2 = BiddingFixture.bidding(bidder, auction2, TradingStatus.WAITING);
+		Bidding auction3Bidding = BiddingFixture.bidding(bidder, auction3, TradingStatus.WAITING);
+
+		biddingRepository.saveAll(
+			List.of(auction1Bidding1, auction1Bidding2, auction2Bidding1, auction2Bidding2, auction3Bidding));
+
+		//when
+		biddingQueryRepository.updateBiddingTradingStatus();
+
+		em.flush();
+		em.clear();
+		Bidding foundAuction1Bidding1 = biddingRepository.findById(auction1Bidding1.getId()).orElseThrow();
+		Bidding foundAuction1Bidding2 = biddingRepository.findById(auction1Bidding2.getId()).orElseThrow();
+		Bidding foundAuction2Bidding1 = biddingRepository.findById(auction2Bidding1.getId()).orElseThrow();
+		Bidding foundAuction2Bidding2 = biddingRepository.findById(auction2Bidding2.getId()).orElseThrow();
+		Bidding foundAuction3Bidding = biddingRepository.findById(auction3Bidding.getId()).orElseThrow();
+
+		//then
+		assertThat(foundAuction1Bidding1.getTradingStatus()).isEqualTo(TradingStatus.WAITING);
+		assertThat(foundAuction1Bidding2.getTradingStatus()).isEqualTo(TradingStatus.PREPARING);
+		assertThat(foundAuction2Bidding1.getTradingStatus()).isEqualTo(TradingStatus.WAITING);
+		assertThat(foundAuction2Bidding2.getTradingStatus()).isEqualTo(TradingStatus.PREPARING);
+		assertThat(foundAuction3Bidding.getTradingStatus()).isEqualTo(TradingStatus.WAITING);
 	}
 }

--- a/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
+++ b/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
@@ -22,6 +22,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.service.AuctionService;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
@@ -152,6 +153,7 @@ class BiddingServiceTest {
 		User bidder = UserFixture.user2();
 		Bidding bidding = BiddingFixture.bidding(auction, bidder, TradingStatus.PROGRESSING);
 		ReflectionTestUtils.setField(bidding, "createdAt", LocalDateTime.now());
+		ReflectionTestUtils.setField(auction, "status", AuctionStatus.TRADING);
 
 		given(biddingRepository.findById(1L)).willReturn(Optional.of(bidding));
 

--- a/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
+++ b/core/src/test/java/dev/handsup/bidding/service/BiddingServiceTest.java
@@ -27,6 +27,7 @@ import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
 import dev.handsup.bidding.dto.request.RegisterBiddingRequest;
 import dev.handsup.bidding.dto.response.BiddingResponse;
+import dev.handsup.bidding.repository.BiddingQueryRepository;
 import dev.handsup.bidding.repository.BiddingRepository;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.common.exception.ValidationException;
@@ -43,6 +44,8 @@ class BiddingServiceTest {
 	private final User user = UserFixture.user1();
 	@Mock
 	private BiddingRepository biddingRepository;
+	@Mock
+	private BiddingQueryRepository biddingQueryRepository;
 	@Mock
 	private AuctionService auctionService;
 	@InjectMocks
@@ -171,7 +174,7 @@ class BiddingServiceTest {
 		Bidding bidding2 = BiddingFixture.bidding(auction, bidder, TradingStatus.WAITING,
 			bidding1.getBiddingPrice() + 1000);
 		given(biddingRepository.findById(1L)).willReturn(Optional.of(bidding1));
-		given(biddingRepository.findFirstByTradingStatus(TradingStatus.WAITING)).willReturn(Optional.of(bidding2));
+		given(biddingQueryRepository.findWaitingBiddingLatest(auction)).willReturn(Optional.of(bidding2));
 
 		//when
 		BiddingResponse response = biddingService.cancelTrading(bidding1.getId(), user);

--- a/core/src/test/java/dev/handsup/config/TestAuditingConfig.java
+++ b/core/src/test/java/dev/handsup/config/TestAuditingConfig.java
@@ -1,0 +1,10 @@
+package dev.handsup.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@TestConfiguration
+@EnableJpaAuditing
+public class TestAuditingConfig {
+
+}

--- a/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/BiddingFixture.java
@@ -50,4 +50,13 @@ public class BiddingFixture {
 		);
 	}
 
+	public static Bidding bidding(User user, Auction auction, TradingStatus status, int price) {
+		return Bidding.of(
+			price,
+			auction,
+			user,
+			status
+		);
+	}
+
 }


### PR DESCRIPTION
close #106 
### 📑 작업 상세 내용

- 경매 입찰 종료 시 입찰 상태 변경 스케줄러 추가
  - 입찰 종료된 각 경매들의 최근 입찰을 준비중으로 변경 -> 동적 쿼리로 구현
  - 동적 쿼리 테스트 진행
- 경매 입찰 종료 시 경매 상태 변경 쿼리 수정
  - JPQL -> 동적 쿼리로 구현
  - 기존 repository 테스트 수정
 - 거래 완료 시 경매 완료 상태변경 로직 추가
   - Auction에 거래 완료 및 예외 처리 메서드 추가 
   - 거래 완료 시 경매 완료되는 로직 추가 

### 💫 작업 요약

- 기존 입찰 상태 변경 스케줄러로 구현
- 기존 경매 상태 변경 jpql아닌 동적 쿼리 함수 호출
- 거래 완료 시 경매 완료 상태 변경 메서드 추가

### 🔍 중점적으로 리뷰 할 부분

- biddingService