### PR TITLE
[feat] : 로그인 된 사용자 정보 조회 API 추가, 이메일 중복 체크 에러 해결

### DIFF
--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -9,16 +9,20 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.handsup.auth.annotation.NoAuth;
+import dev.handsup.auth.jwt.JwtAuthorization;
 import dev.handsup.common.dto.PageResponse;
+import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.request.EmailAvailibilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.JoinUserResponse;
+import dev.handsup.user.dto.response.UserDetailResponse;
 import dev.handsup.user.dto.response.UserProfileResponse;
 import dev.handsup.user.dto.response.UserReviewLabelResponse;
 import dev.handsup.user.dto.response.UserReviewResponse;
 import dev.handsup.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -40,6 +44,17 @@ public class UserApiController {
 	) {
 		Long userId = userService.join(request);
 		JoinUserResponse response = JoinUserResponse.from(userId);
+		return ResponseEntity.ok(response);
+	}
+
+	@GetMapping("/api/users")
+	@Operation(summary = "로그인 된 사용자 정보 조회 API",
+		description = "토큰으로 로그인 되어있는 사용자의 정보를 조회한다")
+	@ApiResponse(useReturnTypeSchema = true)
+	public ResponseEntity<UserDetailResponse> getAuthorizedUser(
+		@Parameter(hidden = true) @JwtAuthorization User user
+	) {
+		UserDetailResponse response = UserDetailResponse.of(user);
 		return ResponseEntity.ok(response);
 	}
 

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -12,7 +12,7 @@ import dev.handsup.auth.annotation.NoAuth;
 import dev.handsup.auth.jwt.JwtAuthorization;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.user.domain.User;
-import dev.handsup.user.dto.request.EmailAvailibilityRequest;
+import dev.handsup.user.dto.request.EmailAvailabilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.JoinUserResponse;
@@ -62,7 +62,7 @@ public class UserApiController {
 	@GetMapping("/api/users/check-email")
 	@Operation(summary = "이메일 중복 체크 API", description = "이메일이 이미 사용중인지 체크한다")
 	public ResponseEntity<EmailAvailabilityResponse> checkEmailAvailability(
-		@Valid @RequestBody EmailAvailibilityRequest request
+		@Valid @RequestBody EmailAvailabilityRequest request
 	) {
 		EmailAvailabilityResponse response = userService.isEmailAvailable(request);
 		return ResponseEntity.ok(response);

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import dev.handsup.auth.annotation.NoAuth;
@@ -62,7 +63,7 @@ public class UserApiController {
 	@GetMapping("/api/users/check-email")
 	@Operation(summary = "이메일 중복 체크 API", description = "이메일이 이미 사용중인지 체크한다")
 	public ResponseEntity<EmailAvailabilityResponse> checkEmailAvailability(
-		@Valid @RequestBody EmailAvailabilityRequest request
+		@Valid @RequestParam("email") EmailAvailabilityRequest request
 	) {
 		EmailAvailabilityResponse response = userService.isEmailAvailable(request);
 		return ResponseEntity.ok(response);

--- a/api/src/main/java/dev/handsup/user/controller/UserApiController.java
+++ b/api/src/main/java/dev/handsup/user/controller/UserApiController.java
@@ -13,7 +13,6 @@ import dev.handsup.auth.annotation.NoAuth;
 import dev.handsup.auth.jwt.JwtAuthorization;
 import dev.handsup.common.dto.PageResponse;
 import dev.handsup.user.domain.User;
-import dev.handsup.user.dto.request.EmailAvailabilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.JoinUserResponse;
@@ -63,9 +62,9 @@ public class UserApiController {
 	@GetMapping("/api/users/check-email")
 	@Operation(summary = "이메일 중복 체크 API", description = "이메일이 이미 사용중인지 체크한다")
 	public ResponseEntity<EmailAvailabilityResponse> checkEmailAvailability(
-		@Valid @RequestParam("email") EmailAvailabilityRequest request
+		@RequestParam("email") String email
 	) {
-		EmailAvailabilityResponse response = userService.isEmailAvailable(request);
+		EmailAvailabilityResponse response = userService.isEmailAvailable(email);
 		return ResponseEntity.ok(response);
 	}
 

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -88,13 +88,11 @@ class UserApiControllerTest extends ApiTestSupport {
 		// given
 		String existedEmail = user.getEmail();
 		String requestEmail = "hello" + existedEmail;
-		EmailAvailabilityRequest request = EmailAvailabilityRequest.from(requestEmail);
 
 		// when
 		ResultActions actions = mockMvc.perform(
 			get("/api/users/check-email")
-				.contentType(APPLICATION_JSON)
-				.content(toJson(request))
+				.param("email", requestEmail)
 		);
 
 		// then
@@ -107,13 +105,11 @@ class UserApiControllerTest extends ApiTestSupport {
 	void checkEmailAvailabilityFailTest() throws Exception {
 		// given
 		String existedEmail = user.getEmail();
-		EmailAvailabilityRequest request = EmailAvailabilityRequest.from(existedEmail);
 
 		// when
 		ResultActions actions = mockMvc.perform(
 			get("/api/users/check-email")
-				.contentType(APPLICATION_JSON)
-				.content(toJson(request))
+				.param("email", existedEmail)
 		);
 
 		// then

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -31,7 +31,7 @@ import dev.handsup.review.domain.UserReviewLabel;
 import dev.handsup.review.repository.ReviewLabelRepository;
 import dev.handsup.review.repository.ReviewRepository;
 import dev.handsup.user.domain.User;
-import dev.handsup.user.dto.request.EmailAvailibilityRequest;
+import dev.handsup.user.dto.request.EmailAvailabilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.repository.UserRepository;
 import dev.handsup.user.repository.UserReviewLabelRepository;
@@ -88,7 +88,7 @@ class UserApiControllerTest extends ApiTestSupport {
 		// given
 		String existedEmail = user.getEmail();
 		String requestEmail = "hello" + existedEmail;
-		EmailAvailibilityRequest request = EmailAvailibilityRequest.from(requestEmail);
+		EmailAvailabilityRequest request = EmailAvailabilityRequest.from(requestEmail);
 
 		// when
 		ResultActions actions = mockMvc.perform(
@@ -107,7 +107,7 @@ class UserApiControllerTest extends ApiTestSupport {
 	void checkEmailAvailabilityFailTest() throws Exception {
 		// given
 		String existedEmail = user.getEmail();
-		EmailAvailibilityRequest request = EmailAvailibilityRequest.from(existedEmail);
+		EmailAvailabilityRequest request = EmailAvailabilityRequest.from(existedEmail);
 
 		// when
 		ResultActions actions = mockMvc.perform(

--- a/core/src/main/java/dev/handsup/user/dto/request/EmailAvailabilityRequest.java
+++ b/core/src/main/java/dev/handsup/user/dto/request/EmailAvailabilityRequest.java
@@ -7,7 +7,7 @@ import jakarta.validation.constraints.Pattern;
 import lombok.Builder;
 
 @Builder(access = PRIVATE)
-public record EmailAvailibilityRequest(
+public record EmailAvailabilityRequest(
 
 	@NotBlank(message = "email 은 필수입니다.")
 	@Pattern(regexp = "^[0-9a-zA-Z]([-_.]?[0-9a-zA-Z]){0,19}"
@@ -15,8 +15,8 @@ public record EmailAvailibilityRequest(
 		message = "이메일 주소 양식을 확인해주세요.")
 	String email
 ) {
-	public static EmailAvailibilityRequest from(String email) {
-		return EmailAvailibilityRequest.builder()
+	public static EmailAvailabilityRequest from(String email) {
+		return EmailAvailabilityRequest.builder()
 			.email(email)
 			.build();
 	}

--- a/core/src/main/java/dev/handsup/user/dto/response/UserDetailResponse.java
+++ b/core/src/main/java/dev/handsup/user/dto/response/UserDetailResponse.java
@@ -1,0 +1,30 @@
+package dev.handsup.user.dto.response;
+
+import dev.handsup.user.domain.Address;
+import dev.handsup.user.domain.User;
+
+public record UserDetailResponse(
+	Long userId,
+	String email,
+	String password,
+	String nickname,
+	int score,
+	Address address,
+	String profileImageUrl,
+	int reportCount,
+	long readNotificationCount
+) {
+	public static UserDetailResponse of(User user) {
+		return new UserDetailResponse(
+			user.getId(),
+			user.getEmail(),
+			user.getPassword(),
+			user.getNickname(),
+			user.getScore(),
+			user.getAddress(),
+			user.getProfileImageUrl(),
+			user.getReportCount(),
+			user.getReadNotificationCount()
+		);
+	}
+}

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -20,7 +20,6 @@ import dev.handsup.common.exception.ValidationException;
 import dev.handsup.review.repository.ReviewRepository;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.UserMapper;
-import dev.handsup.user.dto.request.EmailAvailabilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.UserProfileResponse;
@@ -74,8 +73,8 @@ public class UserService {
 		return savedUser.getId();
 	}
 
-	public EmailAvailabilityResponse isEmailAvailable(EmailAvailabilityRequest request) {
-		boolean isEmailAvailable = userRepository.findByEmail(request.email()).isEmpty();
+	public EmailAvailabilityResponse isEmailAvailable(String email) {
+		boolean isEmailAvailable = userRepository.findByEmail(email).isEmpty();
 		return EmailAvailabilityResponse.from(isEmailAvailable);
 	}
 

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -20,7 +20,7 @@ import dev.handsup.common.exception.ValidationException;
 import dev.handsup.review.repository.ReviewRepository;
 import dev.handsup.user.domain.User;
 import dev.handsup.user.dto.UserMapper;
-import dev.handsup.user.dto.request.EmailAvailibilityRequest;
+import dev.handsup.user.dto.request.EmailAvailabilityRequest;
 import dev.handsup.user.dto.request.JoinUserRequest;
 import dev.handsup.user.dto.response.EmailAvailabilityResponse;
 import dev.handsup.user.dto.response.UserProfileResponse;
@@ -74,7 +74,7 @@ public class UserService {
 		return savedUser.getId();
 	}
 
-	public EmailAvailabilityResponse isEmailAvailable(EmailAvailibilityRequest request) {
+	public EmailAvailabilityResponse isEmailAvailable(EmailAvailabilityRequest request) {
 		boolean isEmailAvailable = userRepository.findByEmail(request.email()).isEmpty();
 		return EmailAvailabilityResponse.from(isEmailAvailable);
 	}


### PR DESCRIPTION
close #113
close #115 

### 💫 작업 요약

- 로그인 되어있는 유저 정보 조회 API 
- 이메일 중복 체크 API 에러 해결

### 🔍 중점적으로 리뷰 할 부분

- 컨트롤러에서 서비스 레이어 까지 안 가고 반환하도록 구현했습니다.
- 이메일 중복 체크 API 의 요청에서
@RequestBody 를 아래로 변경했습니다.
`@Valid @RequestParam("email") EmailAvailabilityRequest request`