### PR TITLE
[refactor] : 서비스 비즈니스 로직 엔티티로 이동

### DIFF
--- a/api/src/main/java/dev/handsup/bidding/controller/BiddingApiController.java
+++ b/api/src/main/java/dev/handsup/bidding/controller/BiddingApiController.java
@@ -74,9 +74,9 @@ public class BiddingApiController {
 	@ApiResponse(useReturnTypeSchema = true)
 	public ResponseEntity<BiddingResponse> completeTrading(
 		@PathVariable("biddingId") Long biddingId,
-		@JwtAuthorization User seller
+		@JwtAuthorization User user
 	) {
-		BiddingResponse response = biddingService.completeTrading(biddingId, seller);
+		BiddingResponse response = biddingService.completeTrading(biddingId, user);
 		return ResponseEntity.ok(response);
 	}
 
@@ -85,9 +85,9 @@ public class BiddingApiController {
 	@ApiResponse(useReturnTypeSchema = true)
 	public ResponseEntity<BiddingResponse> cancelTrading(
 		@PathVariable("biddingId") Long biddingId,
-		@JwtAuthorization User seller
+		@JwtAuthorization User user
 	) {
-		BiddingResponse response = biddingService.cancelTrading(biddingId, seller);
+		BiddingResponse response = biddingService.cancelTrading(biddingId, user);
 		return ResponseEntity.ok(response);
 	}
 }

--- a/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/chat/controller/ChatRoomApiControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
+import dev.handsup.auction.exception.AuctionErrorCode;
 import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.bidding.domain.Bidding;
@@ -115,8 +116,8 @@ class ChatRoomApiControllerTest extends ApiTestSupport {
 				.header(AUTHORIZATION, "Bearer " + accessToken)
 				.contentType(APPLICATION_JSON))
 			.andExpect(status().isBadRequest())
-			.andExpect(jsonPath("$.message").value(ChatRoomErrorCode.NOT_TRADING_AUCTION.getMessage()))
-			.andExpect(jsonPath("$.code").value(ChatRoomErrorCode.NOT_TRADING_AUCTION.getCode()));
+			.andExpect(jsonPath("$.message").value(AuctionErrorCode.NOT_TRADING_AUCTION.getMessage()))
+			.andExpect(jsonPath("$.code").value(AuctionErrorCode.NOT_TRADING_AUCTION.getCode()));
 	}
 
 	@DisplayName("[유저가 속한 채팅방을 모두 조회할 수 있다.]")

--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -11,7 +11,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -80,7 +79,6 @@ class ReviewApiControllerTest extends ApiTestSupport {
 		reviewLabelRepository.saveAll(List.of(reviewLabelManner, reviewLabelCheap));
 	}
 
-	@Disabled
 	@Test
 	@Transactional
 	@DisplayName("[리뷰 등록 API] 작성자가 경매에 대한 리뷰를 등록한다")

--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -11,6 +11,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,6 +76,7 @@ class ReviewApiControllerTest extends ApiTestSupport {
 		reviewLabelRepository.saveAll(List.of(reviewLabelManner, reviewLabelCheap));
 	}
 
+	@Disabled
 	@Test
 	@Transactional
 	@DisplayName("[리뷰 등록 API] 작성자가 경매에 대한 리뷰를 등록한다")

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -211,8 +211,8 @@ public class Auction extends TimeBaseEntity {
 		}
 	}
 
-	public void validateIfSeller(User user){
-		if (!Objects.equals(seller.getId(), user.getId())){
+	public void validateIfSeller(User user) {
+		if (!Objects.equals(seller.getId(), user.getId())) {
 			throw new ValidationException(NOT_AUCTION_SELLER);
 		}
 	}

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -159,6 +159,12 @@ public class Auction extends TimeBaseEntity {
 		);
 	}
 
+	public void validateAuctionTrading() {
+		if (status != TRADING) {
+			throw new ValidationException(AuctionErrorCode.NOT_TRADING_AUCTION);
+		}
+	}
+
 	public void updateAuctionStatusTrading() {
 		status = AuctionStatus.TRADING;
 	}

--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -2,6 +2,7 @@ package dev.handsup.auction.domain;
 
 import static dev.handsup.auction.domain.auction_field.AuctionStatus.*;
 import static dev.handsup.common.exception.CommonValidationError.*;
+import static dev.handsup.user.exception.UserErrorCode.*;
 import static jakarta.persistence.CascadeType.*;
 import static jakarta.persistence.ConstraintMode.*;
 import static jakarta.persistence.EnumType.*;
@@ -207,6 +208,12 @@ public class Auction extends TimeBaseEntity {
 	public void validateIfCommentAvailable() {
 		if (status != BIDDING) {
 			throw new ValidationException(CommentErrorCode.COMMENT_NOT_AVAIL_AUCTION);
+		}
+	}
+
+	public void validateIfSeller(User user){
+		if (!Objects.equals(seller.getId(), user.getId())){
+			throw new ValidationException(NOT_AUCTION_SELLER);
 		}
 	}
 }

--- a/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
+++ b/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
@@ -19,7 +19,6 @@ public enum AuctionErrorCode implements ErrorCode {
 
 	NOT_TRADING_AUCTION("거래 상태의 경매가 아닙니다.", "AU_008");
 
-
 	private final String message;
 	private final String code;
 }

--- a/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
+++ b/core/src/main/java/dev/handsup/auction/exception/AuctionErrorCode.java
@@ -15,7 +15,10 @@ public enum AuctionErrorCode implements ErrorCode {
 	NOT_FOUND_PRODUCT_CATEGORY("상품 카테고리를 올바르게 입력해주세요.", "AU_004"),
 	INVALID_SORT_INPUT("정렬 기준을 올바르게 입력해주세요.", "AU_005"),
 	EMPTY_SORT_INPUT("정렬 기준을 입력해주세요.", "AU_006"),
-	CAN_NOT_COMPLETE_AUCTION("경매를 완료 상태로 변경할 수 없습니다.", "AU_007");
+	CAN_NOT_COMPLETE_AUCTION("경매를 완료 상태로 변경할 수 없습니다.", "AU_007"),
+
+	NOT_TRADING_AUCTION("거래 상태의 경매가 아닙니다.", "AU_008");
+
 
 	private final String message;
 	private final String code;

--- a/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
+++ b/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
@@ -63,6 +63,10 @@ public class ChatRoom extends TimeBaseEntity {
 			.build();
 	}
 
+	public User getReceiver(User sender){
+		return this.seller.equals(sender) ? bidder : seller;
+	}
+
 	public void updateCurrentBiddingId(Long currentBiddingId) {
 		this.currentBiddingId = currentBiddingId;
 	}

--- a/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
+++ b/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
@@ -63,7 +63,7 @@ public class ChatRoom extends TimeBaseEntity {
 			.build();
 	}
 
-	public User getReceiver(User sender){
+	public User getReceiver(User sender) {
 		return this.seller.equals(sender) ? bidder : seller;
 	}
 

--- a/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
+++ b/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 public enum ChatRoomErrorCode implements ErrorCode {
 
 	CHAT_ROOM_ALREADY_EXISTS("채팅방이 이미 존재합니다.", "CR_001"),
-	CHAT_ROOM_ACCESS_DENIED("채팅방 조회 권한이 없습니다.", "CR_003"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CR_004"),
 	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005");
 

--- a/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
+++ b/core/src/main/java/dev/handsup/chat/exception/ChatRoomErrorCode.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 public enum ChatRoomErrorCode implements ErrorCode {
 
 	CHAT_ROOM_ALREADY_EXISTS("채팅방이 이미 존재합니다.", "CR_001"),
-	NOT_TRADING_AUCTION("거래 상태의 경매가 아닙니다.", "CR_002"),
 	CHAT_ROOM_ACCESS_DENIED("채팅방 조회 권한이 없습니다.", "CR_003"),
 	NOT_FOUND_CHAT_ROOM("해당 아이디의 채팅방이 존재하지 않습니다.", "CR_004"),
 	NOT_FOUND_CHAT_ROOM_BY_BIDDING_ID("입찰 아이디에 해당하는 채팅방이 존재하지 않습니다.", "CR_005");

--- a/core/src/main/java/dev/handsup/chat/service/ChatMessageService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatMessageService.java
@@ -39,15 +39,7 @@ public class ChatMessageService {
 		ChatMessage savedChatMessage = chatMessageRepository.save(chatMessage);
 
 		User sender = getUserById(request.senderId());
-		User receiver;
-
-		if (chatRoom.getSeller().equals(sender)) {
-			receiver = chatRoom.getBidder();
-		} else {
-			receiver = chatRoom.getSeller();
-		}
-
-		sendMessage(sender, receiver, chatRoom);
+		sendMessage(sender, chatRoom.getReceiver(sender), chatRoom);
 
 		return ChatMessageMapper.toChatMessageResponse(savedChatMessage);
 	}

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -7,8 +7,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.exception.BiddingErrorCode;
 import dev.handsup.bidding.repository.BiddingRepository;
@@ -41,7 +39,7 @@ public class ChatRoomService {
 	public RegisterChatRoomResponse registerChatRoom(Long auctionId, Long biddingId, User user) {
 		Bidding bidding = getBiddingWithAuctionAndBidderById(biddingId);
 		validateAuthorization(user, bidding);
-		validateAuctionTrading(bidding.getAuction());
+		bidding.getAuction().validateAuctionTrading();
 
 		bidding.updateTradingStatusProgressing();
 
@@ -106,13 +104,6 @@ public class ChatRoomService {
 		User seller = bidding.getAuction().getSeller();
 		if (!Objects.equals(user.getId(), seller.getId())) { // 조회자와 경매 판매자가 같은지
 			throw new ValidationException(ChatRoomErrorCode.CHAT_ROOM_ACCESS_DENIED);
-		}
-	}
-
-	// 경매가 거래상태인지
-	private void validateAuctionTrading(Auction auction) {
-		if (auction.getStatus() != AuctionStatus.TRADING) {
-			throw new ValidationException(ChatRoomErrorCode.NOT_TRADING_AUCTION);
 		}
 	}
 

--- a/core/src/main/java/dev/handsup/user/exception/UserErrorCode.java
+++ b/core/src/main/java/dev/handsup/user/exception/UserErrorCode.java
@@ -10,7 +10,8 @@ public enum UserErrorCode implements ErrorCode {
 	NOT_FOUND_USER("해당 아이디의 유저가 존재하지 않습니다.", "U_000"),
 	NOT_FOUND_BY_EMAIL("EMAIL 에 해당하는 사용자가 존재하지 않습니다", "U_001"),
 	DUPLICATED_EMAIL("이미 존재하는 이메일입니다. 회원가입을 다시 진행해주세요.", "U_002"),
-	NON_VALIDATED_EMAIL("이메일 주소 양식을 확인해주세요.", "U_003");
+	NON_VALIDATED_EMAIL("이메일 주소 양식을 확인해주세요.", "U_003"),
+	NOT_AUCTION_SELLER("판매자에게만 부여되는 권한입니다.", "U_004");
 
 	private final String message;
 	private final String code;

--- a/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
+++ b/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
@@ -17,7 +17,6 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.bidding.domain.TradingStatus;
@@ -74,7 +73,6 @@ class ChatRoomServiceTest {
 		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 
 		given(auction.getSeller()).willReturn(seller); //validateAuthorization
-		given(auction.getStatus()).willReturn(AuctionStatus.TRADING);
 		given(chatRoomRepository.findByAuctionIdAndBidder(1L, bidder))
 			.willReturn(Optional.empty());
 		given(chatRoomRepository.save(any(ChatRoom.class))).willReturn(chatRoom);
@@ -97,7 +95,6 @@ class ChatRoomServiceTest {
 		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
 
 		given(auction.getSeller()).willReturn(seller); //validateAuthorization
-		given(auction.getStatus()).willReturn(AuctionStatus.TRADING);
 		given(chatRoomRepository.findByAuctionIdAndBidder(1L, bidder))
 			.willReturn(Optional.of(chatRoom));
 

--- a/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
+++ b/core/src/test/java/dev/handsup/chat/service/ChatRoomServiceTest.java
@@ -93,8 +93,6 @@ class ChatRoomServiceTest {
 		ChatRoom chatRoom = ChatRoomFixture.chatRoom(bidding);
 
 		given(biddingRepository.findBiddingWithAuctionAndBidder(anyLong())).willReturn(Optional.of(bidding));
-
-		given(auction.getSeller()).willReturn(seller); //validateAuthorization
 		given(chatRoomRepository.findByAuctionIdAndBidder(1L, bidder))
 			.willReturn(Optional.of(chatRoom));
 


### PR DESCRIPTION
### 📑 작업 상세 내용

- 채팅 등록 시 수신자 결정 비즈니스 로직
 - ChatRoom에 책임 부여 
- 판매자 권한 체크 비즈니스 로직
  - Auction에 책임 부여
  - biddingService, chatRoomService 같이 쓰기 위해 에러 코드 단일화  
  - 변경에 따라 불필요해진 stubbing 삭제
### 💫 작업 요약

- 비즈니스 로직 엔티티 이동

### 🔍 중점적으로 리뷰 할 부분

- Auction.java
- ChatRoom.java
- ChatRoomService.java