### PR TITLE
[feat] : 경매 종료 시 입찰 없으면 경매 상태 변경

### DIFF
--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -47,9 +47,7 @@ import dev.handsup.user.repository.UserRepository;
 @DisplayName("[Review 통합 테스트]")
 class ReviewApiControllerTest extends ApiTestSupport {
 
-	private Auction auction;
 	private final Review review = ReviewFixture.review(1L);
-
 	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
 		1L, ReviewLabelValue.MANNER.getDescription()
 	);
@@ -57,6 +55,7 @@ class ReviewApiControllerTest extends ApiTestSupport {
 		2L, ReviewLabelValue.CHEAP_PRICE.getDescription()
 	);
 	private final List<Long> reviewLabelIds = List.of(1L, 2L);
+	private Auction auction;
 	@Autowired
 	private ReviewRepository reviewRepository;
 	@Autowired

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepository.java
@@ -16,5 +16,5 @@ public interface AuctionQueryRepository {
 
 	Slice<Auction> findByProductCategories(List<ProductCategory> productCategories, Pageable pageable);
 
-	void updateAuctionStatusTrading();
+	void updateAuctionStatusAfterEndDate();
 }

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -98,11 +98,19 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 
 	@Override
 	@Transactional
-	public void updateAuctionStatusTrading() {
+	public void updateAuctionStatusAfterEndDate() {
+		queryFactory
+			.update(auction)
+			.set(auction.status, AuctionStatus.CANCELED)
+			.where(auction.endDate.eq(LocalDate.now().minusDays(1)),
+				auction.biddingCount.eq(0))
+			.execute();
+
 		queryFactory
 			.update(auction)
 			.set(auction.status, AuctionStatus.TRADING)
-			.where(auction.endDate.eq(LocalDate.now().minusDays(1)))
+			.where(auction.endDate.eq(LocalDate.now().minusDays(1)),
+				auction.biddingCount.goe(1))
 			.execute();
 	}
 

--- a/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
+++ b/core/src/main/java/dev/handsup/auction/scheduler/AuctionScheduler.java
@@ -4,6 +4,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import dev.handsup.auction.repository.auction.AuctionQueryRepository;
+import dev.handsup.bidding.repository.BiddingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -12,9 +13,10 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class AuctionScheduler {
 	private final AuctionQueryRepository auctionQueryRepository;
+	private final BiddingRepository biddingRepository;
 
 	@Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
 	public void updateAuctionStatus() {
-		auctionQueryRepository.updateAuctionStatusTrading();
+		auctionQueryRepository.updateAuctionStatusAfterEndDate();
 	}
 }

--- a/core/src/main/java/dev/handsup/comment/dto/response/CommentResponse.java
+++ b/core/src/main/java/dev/handsup/comment/dto/response/CommentResponse.java
@@ -5,15 +5,17 @@ public record CommentResponse(
 	String nickname,
 	String profileImageUrl,
 	String content,
-	boolean isSeller
+	boolean isSeller,
+	String createdAt
 ) {
 	public static CommentResponse of(
 		Long writerId,
 		String nickname,
 		String profileImageUrl,
 		String content,
-		boolean isSeller
+		boolean isSeller,
+		String createdAt
 	) {
-		return new CommentResponse(writerId, nickname, profileImageUrl, content, isSeller);
+		return new CommentResponse(writerId, nickname, profileImageUrl, content, isSeller, createdAt);
 	}
 }

--- a/core/src/main/java/dev/handsup/comment/mapper/CommentMapper.java
+++ b/core/src/main/java/dev/handsup/comment/mapper/CommentMapper.java
@@ -22,7 +22,8 @@ public class CommentMapper {
 			comment.getWriter().getNickname(),
 			comment.getWriter().getProfileImageUrl(),
 			comment.getContent(),
-			comment.getAuction().isSeller(writer)
+			comment.getAuction().isSeller(writer),
+			comment.getCreatedAt().toString()
 		);
 	}
 }

--- a/core/src/test/java/dev/handsup/comment/service/CommentServiceTest.java
+++ b/core/src/test/java/dev/handsup/comment/service/CommentServiceTest.java
@@ -3,6 +3,7 @@ package dev.handsup.comment.service;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -15,6 +16,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import dev.handsup.auction.domain.Auction;
 import dev.handsup.auction.repository.auction.AuctionRepository;
@@ -55,6 +57,7 @@ class CommentServiceTest {
 		RegisterCommentRequest request = new RegisterCommentRequest("와");
 
 		Comment comment = CommentFixture.comment(auction, writer);
+		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
 
 		given(auctionRepository.findById(auction.getId())).willReturn(Optional.of(auction));
 		given(commentRepository.save(any(Comment.class))).willReturn(comment);
@@ -72,6 +75,7 @@ class CommentServiceTest {
 		//given
 		PageRequest pageRequest = PageRequest.of(0, 5);
 		Comment comment = CommentFixture.comment(auction, writer);
+		ReflectionTestUtils.setField(comment, "createdAt", LocalDateTime.now());
 
 		given(auctionRepository.findById(auction.getId()))
 			.willReturn(Optional.of(auction));


### PR DESCRIPTION
close #129 
### 📑 작업 상세 내용

- 입찰 기간(auction.endDate) 종료  시 입찰자 없으면 경매 상태 `CANCELED`로 변경
  - AuctionQueryRepositoryImpl` 수정 
  - caseBuilder로 분기 처리하려 그랬으나 enum 타입 인식 못하는 듯함 
  -  Could not determine ValueMapping for SqmParameter: SqmPositionalParameter(2) 
- 댓글 응답값에 생성 시간 추가 

### 💫 작업 요약

- 입찰 기간 종료 시 입찰자 없으면 CANCELED로 변경
- 댓글 응답값 추가

### 🔍 중점적으로 리뷰 할 부분

- `AuctionQueryRepositoryImpl` 및 테스트