### PR TITLE
[fix] : 유저의 읽은 알림 수를 데이터베이스에 반영

### DIFF
--- a/core/src/main/java/dev/handsup/auction/domain/Auction.java
+++ b/core/src/main/java/dev/handsup/auction/domain/Auction.java
@@ -81,7 +81,7 @@ public class Auction extends TimeBaseEntity {
 	private int currentBiddingPrice;
 
 	@Column(name = "buy_price")
-	private int buyPrice;
+	private Integer buyPrice;
 
 	@Column(name = "end_date", nullable = false)
 	private LocalDate endDate;

--- a/core/src/main/java/dev/handsup/notification/service/NotificationService.java
+++ b/core/src/main/java/dev/handsup/notification/service/NotificationService.java
@@ -48,7 +48,7 @@ public class NotificationService {
 		notificationRepository.save(notification);
 	}
 
-	@Transactional(readOnly = true)
+	@Transactional
 	public PageResponse<NotificationResponse> getNotifications(User user, Pageable pageable) {
 		Slice<NotificationResponse> notificationResponsePage = notificationRepository
 			.findByReceiverEmailOrderByCreatedAtDesc(user.getEmail(), pageable)
@@ -67,8 +67,9 @@ public class NotificationService {
 				);
 			});
 
-		// User 의 readNotificationCount 갱신
-		user.setReadNotificationCount(notificationResponsePage.getSize());
+		// 사용자의 읽은 알림 수 갱신
+		user.setReadNotificationCount(notificationResponsePage.getContent().size());
+		userRepository.save(user);
 
 		return CommonMapper.toPageResponse(notificationResponsePage);
 	}

--- a/core/src/main/java/dev/handsup/notification/service/NotificationService.java
+++ b/core/src/main/java/dev/handsup/notification/service/NotificationService.java
@@ -68,7 +68,7 @@ public class NotificationService {
 			});
 
 		// 사용자의 읽은 알림 수 갱신
-		user.setReadNotificationCount(notificationResponsePage.getContent().size());
+		user.updateReadNotificationCount(notificationResponsePage.getContent().size());
 		userRepository.save(user);
 
 		return CommonMapper.toPageResponse(notificationResponsePage);

--- a/core/src/main/java/dev/handsup/user/dto/response/UserBuyHistoryResponse.java
+++ b/core/src/main/java/dev/handsup/user/dto/response/UserBuyHistoryResponse.java
@@ -7,7 +7,7 @@ public record UserBuyHistoryResponse(
 	String auctionImageUrl,
 	String auctionCreatedAt,
 	String auctionEndDateTime,
-	int buyPrice,
+	Integer buyPrice,
 	String auctionStatus
 ) {
 	public static UserBuyHistoryResponse of(
@@ -16,7 +16,7 @@ public record UserBuyHistoryResponse(
 		String auctionImageUrl,
 		String auctionCreatedAt,
 		String auctionEndDateTime,
-		int buyPrice,
+		Integer buyPrice,
 		String auctionStatus
 	) {
 		return new UserBuyHistoryResponse(

--- a/core/src/main/java/dev/handsup/user/dto/response/UserSaleHistoryResponse.java
+++ b/core/src/main/java/dev/handsup/user/dto/response/UserSaleHistoryResponse.java
@@ -8,7 +8,7 @@ public record UserSaleHistoryResponse(
 	String auctionCreatedAt,
 	String auctionEndDateTime,
 	int maxBiddingPrice,
-	int salePrice,
+	Integer salePrice,
 	String auctionStatus
 ) {
 	public static UserSaleHistoryResponse of(
@@ -18,7 +18,7 @@ public record UserSaleHistoryResponse(
 		String auctionCreatedAt,
 		String auctionEndDateTime,
 		int maxBiddingPrice,
-		int salePrice,
+		Integer salePrice,
 		String auctionStatus
 	) {
 		return new UserSaleHistoryResponse(


### PR DESCRIPTION
close #136 

### 📑 작업 상세 내용

- user 의 필드를 update 했지만 db 에 반영이 안되는 `영속성 이슈`였습니다.
- 따라서 Update 후에 save(user) 해줘서 해결했습니다.
- Auction 엔티티의 buyPrice 의 Type 변경 
  - `private Integer buyPrice;`
  - `Null 이 int 에 할당 불가한 에러` 발견

### 💫 작업 요약

- 유저의 읽은 알림 수를 데이터베이스에 반영
