### PR TITLE
[feat] : 쿠키 세팅, 댓글 알림 추가, 판매내역 오류 수정

### DIFF
--- a/api/src/test/java/dev/handsup/comment/controller/CommentApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/comment/controller/CommentApiControllerTest.java
@@ -24,6 +24,7 @@ import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.CommentFixture;
 import dev.handsup.fixture.ProductFixture;
 import dev.handsup.fixture.UserFixture;
+import dev.handsup.notification.repository.FCMTokenRepository;
 import dev.handsup.user.domain.User;
 
 @DisplayName("[Comment 통합 테스트]")
@@ -35,6 +36,8 @@ class CommentApiControllerTest extends ApiTestSupport {
 	private ProductCategory productCategory;
 	@Autowired
 	private CommentRepository commentRepository;
+	@Autowired
+	private FCMTokenRepository fcmTokenRepository;
 
 	@BeforeEach
 	void setUp() {
@@ -47,6 +50,7 @@ class CommentApiControllerTest extends ApiTestSupport {
 	@DisplayName("[댓글을 등록할 수 있다.]")
 	@Test
 	void registerComment() throws Exception {
+		fcmTokenRepository.saveFcmToken(seller.getEmail(), "fcmToken123");
 		RegisterCommentRequest request = RegisterCommentRequest.of("와");
 
 		mockMvc.perform(post("/api/auctions/{auctionId}/comments", auction.getId())

--- a/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/review/controller/ReviewApiControllerTest.java
@@ -49,10 +49,10 @@ class ReviewApiControllerTest extends ApiTestSupport {
 
 	private final Review review = ReviewFixture.review(1L);
 	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
-		1L, ReviewLabelValue.MANNER.getDescription()
+		1L, ReviewLabelValue.MANNER.getLabel()
 	);
 	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
-		2L, ReviewLabelValue.CHEAP_PRICE.getDescription()
+		2L, ReviewLabelValue.CHEAP_PRICE.getLabel()
 	);
 	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 	private Auction auction;

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -278,10 +278,6 @@ class UserApiControllerTest extends ApiTestSupport {
 			auction3.getProduct().getProductCategory()
 		));
 		auctionRepository.saveAll(List.of(auction1, auction2, auction3));
-		Bidding bidding1 = BiddingFixture.bidding(1L, auction1, user);
-		Bidding bidding2 = BiddingFixture.bidding(2L, auction2, user);
-		Bidding bidding3 = BiddingFixture.bidding(3L, auction3, user);
-		biddingRepository.saveAll(List.of(bidding1, bidding2, bidding3));
 
 		PageRequest pageRequest = PageRequest.of(0, 5);
 

--- a/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/user/controller/UserApiControllerTest.java
@@ -130,8 +130,8 @@ class UserApiControllerTest extends ApiTestSupport {
 	@DisplayName("[[유저 리뷰 라벨 조회 API] 유저의 리뷰 라벨이 id 기준 오름차순으로 반환된다]")
 	void getUserReviewLabelsTest() throws Exception {
 		// given
-		ReviewLabel reviewLabel1 = ReviewLabel.from(ReviewLabelValue.MANNER.getDescription());
-		ReviewLabel reviewLabel2 = ReviewLabel.from(ReviewLabelValue.CHEAP_PRICE.getDescription());
+		ReviewLabel reviewLabel1 = ReviewLabel.from(ReviewLabelValue.MANNER.getLabel());
+		ReviewLabel reviewLabel2 = ReviewLabel.from(ReviewLabelValue.CHEAP_PRICE.getLabel());
 		reviewLabelRepository.saveAll(
 			List.of(reviewLabel1, reviewLabel2)
 		);

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionRepository.java
@@ -7,6 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import dev.handsup.auction.domain.Auction;
+import dev.handsup.auction.domain.auction_field.AuctionStatus;
+import dev.handsup.bidding.domain.Bidding;
 import dev.handsup.user.domain.User;
 
 public interface AuctionRepository extends JpaRepository<Auction, Long> {
@@ -14,4 +16,9 @@ public interface AuctionRepository extends JpaRepository<Auction, Long> {
 	@Query("select distinct b.auction from Bookmark b " +
 		"where b.user = :user")
 	Slice<Auction> findBookmarkAuction(@Param("user") User user, Pageable pageable);
+
+	Slice<Auction> findBySeller_IdOrderByCreatedAtDesc(Long sellerId, Pageable pageable);
+
+	Slice<Auction> findBySeller_IdAndStatusOrderByCreatedAtDesc(
+		Long sellerId, AuctionStatus auctionStatus, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/auth/dto/AuthMapper.java
+++ b/core/src/main/java/dev/handsup/auth/dto/AuthMapper.java
@@ -40,7 +40,7 @@ public class AuthMapper {
 			.path("/")
 			.sameSite("None")
 			.httpOnly(true)
-			.secure(true)
+			.secure(false)
 			.maxAge(Duration.ofDays(15))
 			.build();
 	}

--- a/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
+++ b/core/src/main/java/dev/handsup/bidding/repository/BiddingRepository.java
@@ -37,9 +37,4 @@ public interface BiddingRepository extends JpaRepository<Bidding, Long> {
 
 	Slice<Bidding> findByBidderAndAuction_StatusOrderByAuction_CreatedAtDesc(
 		User bidder, AuctionStatus auctionStatus, Pageable pageable);
-
-	Slice<Bidding> findByAuction_Seller_IdOrderByAuction_CreatedAtDesc(Long sellerId, Pageable pageable);
-
-	Slice<Bidding> findByAuction_Seller_IdAndAuction_StatusOrderByAuction_CreatedAtDesc(
-		Long sellerId, AuctionStatus auctionStatus, Pageable pageable);
 }

--- a/core/src/main/java/dev/handsup/review/domain/ReviewLabelValue.java
+++ b/core/src/main/java/dev/handsup/review/domain/ReviewLabelValue.java
@@ -15,5 +15,5 @@ public enum ReviewLabelValue {
 	ACCURATE_CONDITION("물품 상태 사진과 같아요"),
 	DIRECT_TRADING("직접 와서 거래해요");
 
-	private final String description;
+	private final String label;
 }

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -11,6 +11,7 @@ import dev.handsup.auction.domain.auction_field.AuctionStatus;
 import dev.handsup.auction.domain.product.product_category.PreferredProductCategory;
 import dev.handsup.auction.domain.product.product_category.ProductCategory;
 import dev.handsup.auction.exception.AuctionErrorCode;
+import dev.handsup.auction.repository.auction.AuctionRepository;
 import dev.handsup.auction.repository.product.PreferredProductCategoryRepository;
 import dev.handsup.auction.repository.product.ProductCategoryRepository;
 import dev.handsup.auth.domain.EncryptHelper;
@@ -45,6 +46,7 @@ public class UserService {
 	private final UserReviewLabelRepository userReviewLabelRepository;
 	private final ReviewRepository reviewRepository;
 	private final BiddingRepository biddingRepository;
+	private final AuctionRepository auctionRepository;
 
 	private void validateDuplicateEmail(String email) {
 		if (userRepository.findByEmail(email).isPresent()) {
@@ -150,18 +152,18 @@ public class UserService {
 		AuctionStatus auctionStatus,
 		Pageable pageable
 	) {
-		Slice<UserSaleHistoryResponse> auctionUserBuyResponsePage;
+		Slice<UserSaleHistoryResponse> auctionUserSaleResponsePage;
 
 		if (auctionStatus == null) {
-			auctionUserBuyResponsePage = biddingRepository
-				.findByAuction_Seller_IdOrderByAuction_CreatedAtDesc(userId, pageable)
-				.map(bidding -> UserMapper.toUserSaleHistoryResponse(bidding.getAuction()));
+			auctionUserSaleResponsePage = auctionRepository
+				.findBySeller_IdOrderByCreatedAtDesc(userId, pageable)
+				.map(UserMapper::toUserSaleHistoryResponse);
 		} else {
-			auctionUserBuyResponsePage = biddingRepository
-				.findByAuction_Seller_IdAndAuction_StatusOrderByAuction_CreatedAtDesc(userId, auctionStatus, pageable)
-				.map(bidding -> UserMapper.toUserSaleHistoryResponse(bidding.getAuction()));
+			auctionUserSaleResponsePage = auctionRepository
+				.findBySeller_IdAndStatusOrderByCreatedAtDesc(userId, auctionStatus, pageable)
+				.map(UserMapper::toUserSaleHistoryResponse);
 		}
 
-		return CommonMapper.toPageResponse(auctionUserBuyResponsePage);
+		return CommonMapper.toPageResponse(auctionUserSaleResponsePage);
 	}
 }

--- a/core/src/test/java/dev/handsup/comment/service/CommentServiceTest.java
+++ b/core/src/test/java/dev/handsup/comment/service/CommentServiceTest.java
@@ -27,6 +27,7 @@ import dev.handsup.comment.repository.CommentRepository;
 import dev.handsup.fixture.AuctionFixture;
 import dev.handsup.fixture.CommentFixture;
 import dev.handsup.fixture.UserFixture;
+import dev.handsup.notification.service.FCMService;
 import dev.handsup.user.domain.User;
 
 @DisplayName("[댓글 서비스 테스트]")
@@ -37,10 +38,10 @@ class CommentServiceTest {
 	private User writer;
 	@Mock
 	private AuctionRepository auctionRepository;
-
 	@Mock
 	private CommentRepository commentRepository;
-
+	@Mock
+	private FCMService fcmService;
 	@InjectMocks
 	private CommentService commentService;
 

--- a/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
+++ b/core/src/test/java/dev/handsup/review/service/ReviewServiceTest.java
@@ -47,10 +47,10 @@ class ReviewServiceTest {
 	private final User writer = UserFixture.user1();
 	private final Review review = ReviewFixture.review();
 	private final ReviewLabel reviewLabelManner = ReviewLabelFixture.reviewLabel(
-		1L, ReviewLabelValue.MANNER.getDescription()
+		1L, ReviewLabelValue.MANNER.getLabel()
 	);
 	private final ReviewLabel reviewLabelCheap = ReviewLabelFixture.reviewLabel(
-		2L, ReviewLabelValue.CHEAP_PRICE.getDescription()
+		2L, ReviewLabelValue.CHEAP_PRICE.getLabel()
 	);
 	private final List<Long> reviewLabelIds = List.of(1L, 2L);
 	private final UserReviewLabel userReviewLabelManner = UserReviewLabelFixture.userReviewLabel(

--- a/core/src/test/java/dev/handsup/user/repository/UserReviewLabelRepositoryTest.java
+++ b/core/src/test/java/dev/handsup/user/repository/UserReviewLabelRepositoryTest.java
@@ -33,7 +33,7 @@ class UserReviewLabelRepositoryTest extends DataJpaTestSupport {
 	@DisplayName("[UserReviewLabel 엔티티의 count 필드를 update 할 수 있다.]")
 	void testUpdateCount() {
 		// given
-		ReviewLabel reviewLabel = ReviewLabel.from(ReviewLabelValue.MANNER.getDescription());
+		ReviewLabel reviewLabel = ReviewLabel.from(ReviewLabelValue.MANNER.getLabel());
 		reviewLabelRepository.save(reviewLabel);
 
 		UserReviewLabel userReviewLabel = UserReviewLabel.of(reviewLabel, user);

--- a/core/src/testFixtures/java/dev/handsup/fixture/ReviewLabelFixture.java
+++ b/core/src/testFixtures/java/dev/handsup/fixture/ReviewLabelFixture.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = PRIVATE)
 public final class ReviewLabelFixture {
 
-	static final String VALUE_MANNER = ReviewLabelValue.MANNER.getDescription();
-	static final String VALUE_CHEAP = ReviewLabelValue.CHEAP_PRICE.getDescription();
+	static final String VALUE_MANNER = ReviewLabelValue.MANNER.getLabel();
+	static final String VALUE_CHEAP = ReviewLabelValue.CHEAP_PRICE.getLabel();
 
 	public static ReviewLabel reviewLabelManner() {
 		return ReviewLabel.from(VALUE_MANNER);


### PR DESCRIPTION
close #139
close #140
close #141

### 📑 작업 상세 내용

- 프론트엔드 쿠키 이슈로 인해서 , 쿠키 secure 세팅을 임시로 false 합니다
- 입찰이 없는 경매는 판매내역에서 조회가 안 됨
  - 입찰이 있든 없든 판매내역에서 경매가 조회되도록 수정

### 💫 작업 요약

- 쿠키 세팅
- 댓글 알림 추가
- 판매내역 오류 수정