### PR TITLE
[feat] : 캐싱 도입, 알림 토큰 에러, 댓글 알림 타입 수정

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -10,6 +10,9 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.1.0'
     // FCM 알림
     implementation 'com.google.firebase:firebase-admin:9.2.0'
+    // 로컬 캐시
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 
     tasks.named('bootJar') {
         enabled = true

--- a/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
+++ b/api/src/main/java/dev/handsup/auction/controller/AuctionApiController.java
@@ -1,5 +1,6 @@
 package dev.handsup.auction.controller;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -58,6 +59,7 @@ public class AuctionApiController {
 	@Operation(summary = "경매 추천 API", description = "정렬 조건에 따라 경매를 추천한다.")
 	@ApiResponse(useReturnTypeSchema = true)
 	@GetMapping("/recommend")
+	@Cacheable(cacheNames = "auctions")
 	public ResponseEntity<PageResponse<RecommendAuctionResponse>> getRecommendAuctions(
 		@RequestParam(value = "si", required = false) String si,
 		@RequestParam(value = "gu", required = false) String gu,
@@ -79,4 +81,5 @@ public class AuctionApiController {
 			pageable);
 		return ResponseEntity.ok(response);
 	}
+
 }

--- a/api/src/main/java/dev/handsup/common/config/CacheConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/CacheConfig.java
@@ -1,0 +1,42 @@
+package dev.handsup.common.config;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import dev.handsup.common.domain.CacheType;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+	@Bean
+	public CacheManager cacheManager() {
+		List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+			.map(cache -> new CaffeineCache(
+					cache.getCacheName(),
+					Caffeine.newBuilder()
+						.recordStats()
+						.expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.SECONDS)
+						.maximumSize(cache.getMaximumSize())
+						.build()
+				)
+			)
+			.collect(Collectors.toList());
+
+		SimpleCacheManager cacheManager = new SimpleCacheManager();
+		cacheManager.setCaches(caches);
+
+		return cacheManager;
+	}
+}

--- a/api/src/main/java/dev/handsup/common/domain/CacheType.java
+++ b/api/src/main/java/dev/handsup/common/domain/CacheType.java
@@ -1,0 +1,26 @@
+package dev.handsup.common.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum CacheType {
+	USERS(
+		"users",      	// 캐시 이름: users
+		10 * 60,       				// 만료 시간: 10 분
+		10000         				// 최대 갯수: 10000
+	);
+
+	CacheType(
+		String cacheName,
+		int expireSecondsAfterWrite,
+		int maximumSize
+	) {
+		this.cacheName = cacheName;
+		this.expireAfterWrite = expireSecondsAfterWrite;
+		this.maximumSize = maximumSize;
+	}
+
+	private final String cacheName;
+	private final int expireAfterWrite;
+	private final int maximumSize;
+}

--- a/api/src/main/java/dev/handsup/common/domain/CacheType.java
+++ b/api/src/main/java/dev/handsup/common/domain/CacheType.java
@@ -4,9 +4,9 @@ import lombok.Getter;
 
 @Getter
 public enum CacheType {
-	USERS(
-		"users",      	// 캐시 이름: users
-		10 * 60,       				// 만료 시간: 10 분
+	AUCTIONS(
+		"auctions",      	// 캐시 이름: users
+		10 * 60,       				// 만료 시간: 5 분
 		10000         				// 최대 갯수: 10000
 	);
 

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     testFixturesAnnotationProcessor 'org.projectlombok:lombok'
     testFixturesCompileOnly 'org.springframework.boot:spring-boot-starter-security'
 
+    // QueryDsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"

--- a/core/src/main/java/dev/handsup/comment/service/CommentService.java
+++ b/core/src/main/java/dev/handsup/comment/service/CommentService.java
@@ -46,7 +46,7 @@ public class CommentService {
 			user.getEmail(),
 			user.getNickname(),
 			auction.getSeller().getEmail(),
-			NotificationType.BOOKMARK,
+			NotificationType.COMMENT,
 			auction
 		);
 	}

--- a/core/src/main/java/dev/handsup/notification/service/FCMService.java
+++ b/core/src/main/java/dev/handsup/notification/service/FCMService.java
@@ -8,11 +8,9 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
 import dev.handsup.auction.domain.Auction;
-import dev.handsup.common.exception.NotFoundException;
 import dev.handsup.common.exception.ValidationException;
 import dev.handsup.notification.domain.NotificationType;
 import dev.handsup.notification.dto.request.SaveFCMTokenRequest;
-import dev.handsup.notification.exception.NotificationErrorCode;
 import dev.handsup.notification.repository.FCMTokenRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,8 +31,9 @@ public class FCMService {
 		NotificationType notificationType,
 		Auction auction
 	) {
-		if (!fcmTokenRepository.hasKey(receiverEmail)) {
-			throw new NotFoundException(NotificationErrorCode.NOT_FOUND_FCM_TOKEN);
+		String fcmToken = fcmTokenRepository.getFcmToken(receiverEmail);
+		if (fcmToken == null) {
+			return;
 		}
 
 		if (notificationType.equals(NotificationType.CANCELED_PURCHASE_TRADING) ||
@@ -42,7 +41,6 @@ public class FCMService {
 			senderNickname = "";
 		}
 
-		String fcmToken = getFcmToken(receiverEmail);
 		Message message = Message.builder()
 			.setNotification(Notification.builder()
 				.setTitle(notificationType.getTitle())
@@ -65,14 +63,6 @@ public class FCMService {
 		} catch (FirebaseMessagingException e) {
 			throw new ValidationException(e.getMessage());
 		}
-	}
-
-	private String getFcmToken(String receiverEmail) {
-		String fcmToken = fcmTokenRepository.getFcmToken(receiverEmail);
-		if (fcmToken == null) {
-			throw new NotFoundException(NotificationErrorCode.NOT_FOUND_FCM_TOKEN);
-		}
-		return fcmToken;
 	}
 
 	public void saveFcmToken(String userEmail, SaveFCMTokenRequest request) {

--- a/core/src/main/java/dev/handsup/notification/service/FCMService.java
+++ b/core/src/main/java/dev/handsup/notification/service/FCMService.java
@@ -52,7 +52,11 @@ public class FCMService {
 		send(message, receiverEmail);
 
 		notificationService.saveNotification(
-			senderEmail, receiverEmail, notificationType.getContent(), notificationType, auction
+			senderEmail,
+			receiverEmail,
+			senderNickname + notificationType.getContent(),
+			notificationType,
+			auction
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/user/service/UserService.java
+++ b/core/src/main/java/dev/handsup/user/service/UserService.java
@@ -150,18 +150,18 @@ public class UserService {
 		AuctionStatus auctionStatus,
 		Pageable pageable
 	) {
-		Slice<UserSaleHistoryResponse> auctionUserBuyResponsePage;
+		Slice<UserSaleHistoryResponse> auctionUserSaleResponsePage;
 
 		if (auctionStatus == null) {
-			auctionUserBuyResponsePage = biddingRepository
+			auctionUserSaleResponsePage = biddingRepository
 				.findByAuction_Seller_IdOrderByAuction_CreatedAtDesc(userId, pageable)
 				.map(bidding -> UserMapper.toUserSaleHistoryResponse(bidding.getAuction()));
 		} else {
-			auctionUserBuyResponsePage = biddingRepository
+			auctionUserSaleResponsePage = biddingRepository
 				.findByAuction_Seller_IdAndAuction_StatusOrderByAuction_CreatedAtDesc(userId, auctionStatus, pageable)
 				.map(bidding -> UserMapper.toUserSaleHistoryResponse(bidding.getAuction()));
 		}
 
-		return CommonMapper.toPageResponse(auctionUserBuyResponsePage);
+		return CommonMapper.toPageResponse(auctionUserSaleResponsePage);
 	}
 }

--- a/core/src/test/java/dev/handsup/notification/domain/service/FCMServiceTest.java
+++ b/core/src/test/java/dev/handsup/notification/domain/service/FCMServiceTest.java
@@ -46,8 +46,6 @@ class FCMServiceTest {
 		// given
 		String receiverEmail = receiver.getEmail();
 		String fcmToken = "fcmToken123";
-
-		given(fcmTokenRepository.hasKey(receiverEmail)).willReturn(true);
 		given(fcmTokenRepository.getFcmToken(receiverEmail)).willReturn(fcmToken);
 
 		// when
@@ -63,25 +61,4 @@ class FCMServiceTest {
 		verify(firebaseMessaging, times(1)).send(any());
 	}
 
-	@Test
-	@DisplayName("[메시지를 보내는데 실패한다 - 메시지 구독자의 FCM 토큰이 없을 때]")
-	void sendMessageFailTest() {
-		// given
-		String receiverEmail = receiver.getEmail();
-		given(fcmTokenRepository.hasKey(receiverEmail)).willReturn(true);
-
-		// when, then
-		assertThatThrownBy(() ->
-			fcmService.sendMessage(
-				"senderEmail",
-				"senderNickname",
-				receiverEmail,
-				NotificationType.BOOKMARK,
-				auction
-			))
-			.isInstanceOf(NotFoundException.class)
-			.hasMessageContaining(NotificationErrorCode.NOT_FOUND_FCM_TOKEN.getMessage());
-
-		verify(firebaseMessaging, never()).sendAsync(any());
-	}
 }

--- a/insert_auction_dummy_data.sql
+++ b/insert_auction_dummy_data.sql
@@ -1,0 +1,22 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_auction_dummy_data;
+CREATE PROCEDURE insert_auction_dummy_data()
+
+BEGIN
+    DECLARE i INT DEFAULT 0;
+    WHILE i < 3000 DO
+            INSERT INTO auction
+            (created_at, updated_at, bidding_count, bookmark_count, current_bidding_price, end_date, init_price, auction_status, title, trade_method, dong, gu, si, buyer_id, product_id, seller_id, buy_price)
+            VALUES
+                (NOW(), NOW(), FLOOR(RAND() * 10), FLOOR(RAND() * 10), 3000, '2024-04-07', 3000, 'BIDDING', '에어팟 거의 새거', 'DIRECT', '동선동', '성북구', '서울시', NULL, 1 + i, 2, NULL);
+            SET i = i + 1;
+        END WHILE;
+END$$
+
+DELIMITER ;
+
+CALL insert_auction_dummy_data();
+
+# ALTER TABLE auction AUTO_INCREMENT = 1;
+# DELETE FROM auction WHERE auction_id >= 1;

--- a/insert_product_dummy_data.sql
+++ b/insert_product_dummy_data.sql
@@ -1,0 +1,19 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_product_dummy_data;
+CREATE PROCEDURE insert_product_dummy_data()
+
+BEGIN
+    DECLARE i INT DEFAULT 0;
+    WHILE i < 3000 DO
+            INSERT INTO product (created_at, updated_at, description, purchase_time, status, product_category_id)
+            VALUES (NOW(), NOW(), '애플 에어팟 맛집입니다^^', 'UNDER_ONE_MONTH', 'CLEAN', 1);
+            SET i = i + 1;
+        END WHILE;
+END$$
+
+DELIMITER ;
+CALL insert_product_dummy_data();
+
+# ALTER TABLE product AUTO_INCREMENT = 1;
+# DELETE FROM product WHERE product_id >= 1;

--- a/insert_product_image_dummy_data.sql
+++ b/insert_product_image_dummy_data.sql
@@ -1,0 +1,19 @@
+DELIMITER $$
+
+DROP PROCEDURE IF EXISTS insert_product_image_dummy_data;
+CREATE PROCEDURE insert_product_image_dummy_data()
+
+BEGIN
+    DECLARE i INT DEFAULT 0;
+    WHILE i < 3000 DO
+            INSERT INTO product_image (created_at, updated_at, image_url, product_id)
+            VALUES (NOW(), NOW(), "image_url_string", i + 1);
+            SET i = i + 1;
+        END WHILE;
+END$$
+
+DELIMITER ;
+CALL insert_product_image_dummy_data();
+
+# ALTER TABLE product_image AUTO_INCREMENT = 1;
+# DELETE FROM product_image WHERE product_image_id >= 1;


### PR DESCRIPTION
close #117 
close #146 
close #147 
close #153 

### 💫 작업 요약

- `로컬 캐시 Caffein` 을 도입한다. 
- 알림 전송하는 API 호출시 수신자의 FcmToken 이 없으면 에러가 나는 상황
  - `FCMService.sendMessage()` 에서 fcmToken null 처리를 로직 수정
- 댓글 알림시 북마크 알림이 가는 이슈
  - `CommetnService.registerComment()` 에서  전송하는 알림의 타입을 `BOOKMARK -> COMMNET` 로 변경 ent
- 알림 저장할 때, content 에 발송자의 닉네임도 함께 저장
