### PR TITLE
[fix] : 수신자 bidder로 고정된 오류 해결 

### DIFF
--- a/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
+++ b/api/src/test/java/dev/handsup/auction/controller/AuctionApiControllerTest.java
@@ -68,7 +68,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(jsonPath("$.description").value(request.description()))
 			.andExpect(jsonPath("$.productStatus").value(request.productStatus()))
 			.andExpect(jsonPath("$.tradeMethod").value(request.tradeMethod()))
-			.andExpect(jsonPath("$.endDate").value(request.endDate().toString()))
+			.andExpect(jsonPath("$.endDate").value(request.endDate().atStartOfDay().toString()))
 			.andExpect(jsonPath("$.initPrice").value(request.initPrice()))
 			.andExpect(jsonPath("$.purchaseTime").value(request.purchaseTime()))
 			.andExpect(jsonPath("$.productCategory").value(request.productCategory()))
@@ -117,7 +117,7 @@ class AuctionApiControllerTest extends ApiTestSupport {
 				jsonPath("$.productCategory").value(product.getProductCategory().getValue()))
 			.andExpect(jsonPath("$.initPrice").value(auction.getInitPrice()))
 			.andExpect(jsonPath("$.currentBiddingPrice").value(auction.getCurrentBiddingPrice()))
-			.andExpect(jsonPath("$.endDate").value(auction.getEndDate().toString()))
+			.andExpect(jsonPath("$.endDate").value(auction.getEndDate().atStartOfDay().toString()))
 			.andExpect(jsonPath("$.productStatus").value(product.getStatus().getLabel()))
 			.andExpect(jsonPath("$.purchaseTime").value(product.getPurchaseTime().getLabel()))
 			.andExpect(jsonPath("$.description").value(product.getDescription()))
@@ -149,9 +149,9 @@ class AuctionApiControllerTest extends ApiTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("$.size").value(2))
 			.andExpect(jsonPath("$.content[0].auctionId").value(auction2.getId()))
-			.andExpect(jsonPath("$.content[0].endDate").value(auction2.getEndDate().toString()))
+			.andExpect(jsonPath("$.content[0].endDate").value(auction2.getEndDate().atStartOfDay().toString()))
 			.andExpect(jsonPath("$.content[1].auctionId").value(auction1.getId()))
-			.andExpect(jsonPath("$.content[1].endDate").value(auction1.getEndDate().toString()))
+			.andExpect(jsonPath("$.content[1].endDate").value(auction1.getEndDate().atStartOfDay().toString()))
 			.andExpect(jsonPath("$.hasNext").value(false));
 	}
 

--- a/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
+++ b/core/src/main/java/dev/handsup/auction/dto/mapper/AuctionMapper.java
@@ -59,7 +59,7 @@ public class AuctionMapper {
 			auction.getStatus().getLabel(),
 			auction.getInitPrice(),
 			auction.getCurrentBiddingPrice(),
-			auction.getEndDate().toString(),
+			auction.getEndDate().atStartOfDay().toString(),
 			product.getStatus().getLabel(),
 			product.getPurchaseTime().getLabel(),
 			product.getDescription(),
@@ -97,7 +97,7 @@ public class AuctionMapper {
 			auction.getBookmarkCount(),
 			auction.getBiddingCount(),
 			auction.getCreatedAt().toString(),
-			auction.getEndDate().toString()
+			auction.getEndDate().atStartOfDay().toString()
 		);
 	}
 

--- a/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
+++ b/core/src/main/java/dev/handsup/chat/domain/ChatRoom.java
@@ -64,7 +64,7 @@ public class ChatRoom extends TimeBaseEntity {
 	}
 
 	public User getReceiver(User sender) {
-		return this.seller.equals(sender) ? bidder : seller;
+		return this.seller.getId().equals(sender.getId()) ? bidder : seller;
 	}
 
 	public void updateCurrentBiddingId(Long currentBiddingId) {

--- a/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
+++ b/core/src/main/java/dev/handsup/chat/service/ChatRoomService.java
@@ -112,6 +112,6 @@ public class ChatRoomService {
 	}
 
 	private User getReceiver(User user, ChatRoom chatRoom) {
-		return chatRoom.getBidder().equals(user) ? chatRoom.getSeller() : chatRoom.getBidder();
+		return chatRoom.getBidder().getId().equals(user.getId()) ? chatRoom.getSeller() : chatRoom.getBidder();
 	}
 }

--- a/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
+++ b/core/src/test/java/dev/handsup/auction/service/AuctionServiceTest.java
@@ -97,12 +97,11 @@ class AuctionServiceTest {
 
 		// when
 		AuctionDetailResponse response = auctionService.registerAuction(request, UserFixture.user1());
-
 		// then
 		assertAll(
 			() -> assertThat(response.title()).isEqualTo(request.title()),
 			() -> assertThat(response.tradeMethod()).isEqualTo(request.tradeMethod()),
-			() -> assertThat(response.endDate()).isEqualTo(request.endDate().toString()),
+			() -> assertThat(response.endDate()).isEqualTo(request.endDate().atStartOfDay().toString()),
 			() -> assertThat(response.purchaseTime()).isEqualTo(request.purchaseTime()),
 			() -> assertThat(response.productCategory()).isEqualTo(request.productCategory())
 		);


### PR DESCRIPTION
### 📑 작업 상세 내용

- 수신자 고정
  - seller와 user 비교 시 객체가 아닌 아이디로 비교하게끔 수정
- 응답시 경매 endDate를 localdatetime으로 변환해 반환
  - 프론트엔드 요청 사항 
### 💫 작업 요약

- receiver 구하는 로직 오류 해결
- endDate 응답값 localDate -> localDateTime

### 🔍 중점적으로 리뷰 할 부분

- 급한 수정사항이라 바로 머지하겠습니다!