### PR TITLE
[chore] : docker compose 활용한 CD 구축

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -76,13 +76,8 @@ jobs:
           password: ${{ secrets.EC2_PASSWORD }}
           port: ${{ secrets.EC2_PORT }}
           script: |
+            cd compose
+            docker rm -f $(docker ps -qa)
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }} 
-            docker stop ${{ secrets.DOCKERHUB_APP_NAME }}
-            docker rm ${{ secrets.DOCKERHUB_APP_NAME }}
-            docker run -d \
-            -p 8080:8080 \
-            -e TZ=Asia/Seoul \
-            --name ${{ secrets.DOCKERHUB_APP_NAME }} \
-            ${{ secrets.DOCKERHUB_USERNAME }}/${{ secrets.DOCKERHUB_APP_NAME }}
-            
+            docker-compose up -d
             docker system prune -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,31 +1,8 @@
 version: "3"
 services:
-  server:
-    image: openjdk:17-alpine
-    container_name: spring_server_hands_up
-    restart: always
-    depends_on:
-      - db-master
-      - redis
-    volumes:
-      - ./api/build/libs:/home
-    command: ["java", "-jar", "/home/api-0.0.1-SNAPSHOT.jar"]
-    ports:
-      - '8080:8080'
-    platform: linux/amd64
-
-  db-master:
-    image: mysql:8.0
-    container_name: master_db_hands_up
-    environment:
-      MYSQL_DATABASE: master_db_hands_up
-      MYSQL_ROOT_PASSWORD: ${MASTER_PASSWORD}
-    ports:
-      - "3306:3306"
-
   redis:
-    image: redis:latest
-    container_name: redis_hands_up
+    image: redis
+    container_name: hands-up-redis
     ports:
-      - '6379:6379'
-    platform: linux/amd64
+      - "6379:6379"
+    restart: always


### PR DESCRIPTION
### 📑 작업 상세 내용

- 프로젝트 내 docker-compose.yml 정리
  - mysql 컨테이너: RDS를 사용하므로 필요없다고 판단하여 삭제하였습니다.
  - spring app 컨테이너: 매번 빌드 후 이미지를 pull 받는 것 보다 인텔리제이 내에서 실행하는게 낫다고 판단해 삭제했습니다.
  - redis만 남겨놓았고, 추후 다른 컨테이너가 필요하면 추가하면 될 것 같습니다.
- EC2 내 docker-compose.yml 작성
  - app, redis 컨테이너를 정의했습니다.
  - docker 컨테이너를 삭제 시 redis 데이터가 사라져서 volume에 데이터 저장 후 mount했습니다.
- cd.yml 수정
  - app 컨테이너와 redis 컨테이너를 한 번에 실행하는 스크립트를 작성했습니다.

### 💫 작업 요약

- docker compose 활용한 CD 구축
- 기존: EC2 내 redis 설치 해 실행, `jar 파일 실행 이미지` 실행
- 현재: Docker compose->` jar 파일 실행 이미지`, `redis 이미지` 각각 컨테이너로 실행

### 🔍 중점적으로 리뷰 할 부분

- notion에 docker-compose.yml 적어놓겠습니다!