### PR TITLE
[feat] : redis 비밀번호 할당, 경매 상태 스케줄러 수정

### DIFF
--- a/api/src/main/java/dev/handsup/common/config/RedisConfig.java
+++ b/api/src/main/java/dev/handsup/common/config/RedisConfig.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
@@ -26,9 +27,18 @@ public class RedisConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
+	@Value("${spring.data.redis.password:}")//
+	private String password;
+
 	@Bean
 	public RedisConnectionFactory redisConnectionFactory() {
-		return new LettuceConnectionFactory(host, port);
+		RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+		config.setHostName(host);
+		config.setPort(port);
+		if (!password.isEmpty()) {
+			config.setPassword(password);
+		}
+		return new LettuceConnectionFactory(config);
 	}
 
 	@Bean

--- a/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
+++ b/core/src/main/java/dev/handsup/auction/repository/auction/AuctionQueryRepositoryImpl.java
@@ -102,14 +102,14 @@ public class AuctionQueryRepositoryImpl implements AuctionQueryRepository {
 		queryFactory
 			.update(auction)
 			.set(auction.status, AuctionStatus.CANCELED)
-			.where(auction.endDate.eq(LocalDate.now().minusDays(1)),
+			.where(auction.endDate.lt(LocalDate.now()),
 				auction.biddingCount.eq(0))
 			.execute();
 
 		queryFactory
 			.update(auction)
 			.set(auction.status, AuctionStatus.TRADING)
-			.where(auction.endDate.eq(LocalDate.now().minusDays(1)),
+			.where(auction.endDate.lt(LocalDate.now()),
 				auction.biddingCount.goe(1))
 			.execute();
 	}

--- a/core/src/main/java/dev/handsup/common/config/RedissonConfig.java
+++ b/core/src/main/java/dev/handsup/common/config/RedissonConfig.java
@@ -15,12 +15,17 @@ public class RedissonConfig {
 	@Value("${spring.data.redis.port}")
 	private int port;
 
+	@Value("${spring.data.redis.password:}")
+	private String password;
+
 	@Bean
 	public RedissonClient redissonClient() {
-		RedissonClient redisson = null;
 		Config config = new Config();
-		config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
-		redisson = Redisson.create(config);
-		return redisson;
+		config.useSingleServer()
+			.setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+		if (!password.isEmpty()) {
+			config.useSingleServer().setPassword(password);
+		}
+		return Redisson.create(config);
 	}
 }


### PR DESCRIPTION
### 📑 작업 상세 내용

- redis 비밀번호 할당
  - 기존에는 redis 보안을 위해 기본 포트 말고 다른 포트 번호를 할당했습니다.
   ```yaml
   command: --port 6385
   ports:
      - "6385:6385"
   expose:
      - "6385"
   ```

    -  패스워드 인증 방식이 보안성이 높을 것 같아 해당 방식으로 변경하였습니다.
      - `command: redis-server --requirepass "pw" `
    - `application.yml`에 spring.data.redis에 password를 추가했습니다.
    - 우분투에서 접속 시 비밀번호 인증 후 redis에 쿼리할 수 있습니다.

- 스케줄러 함수 수정
  - 기존에는 하루가 지난 경매들을 체크해 경매 상태를 변경하였습니다.
  - 스케줄러 돌릴 때 에러가 날 수도 있으므로 이전 날짜 경매들까지 체크하여 상태 변경하도록 수정했습니다.

### 💫 작업 요약
- redis 비밀번호 할당
- 스케줄러 함수 수정
